### PR TITLE
Add project filter to list jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,13 @@ compile-protos-python: install-python-ci-dependencies
 	cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. --python_out=../python/ --grpc_python_out=../python/ --mypy_out=../python/ feast_spark/third_party/grpc/health/v1/*.proto
 
 # Supports feast-dev repo master branch
+<<<<<<< HEAD
 install-python: compile-protos-python
+=======
+install-python: install-python-ci-dependencies
+	cd ${SUBMODULE_DIR}; make install-python
+>>>>>>> Revert command
 	cd ${ROOT_DIR}; python -m pip install -e python
-	cd ${SUBMODULE_DIR}; make compile-protos-python
-	cd ${SUBMODULE_DIR}; python -m pip install -e sdk/python
 
 lint-python:
 	cd ${ROOT_DIR}/python ; mypy feast_spark/

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ compile-protos-python: install-python-ci-dependencies
 install-python: compile-protos-python
 	cd ${ROOT_DIR}; python -m pip install -e python
 	cd ${SUBMODULE_DIR}; make install-python
-	cd ${ROOT_DIR}; python -m pip install -e python
 
 lint-python:
 	cd ${ROOT_DIR}/python ; mypy feast_spark/

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ compile-protos-python: install-python-ci-dependencies
 # Supports feast-dev repo master branch
 install-python: compile-protos-python
 	cd ${ROOT_DIR}; python -m pip install -e python
-	cd ${SUBMODULE_DIR}; make install-python
+	cd ${SUBMODULE_DIR}; make compile-protos-python
+	cd ${SUBMODULE_DIR}; python -m pip install -e sdk/python
 
 lint-python:
 	cd ${ROOT_DIR}/python ; mypy feast_spark/

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ compile-protos-python: install-python-ci-dependencies
 install-python: compile-protos-python
 	cd ${ROOT_DIR}; python -m pip install -e python
 	cd ${SUBMODULE_DIR}; make install-python
+	cd ${ROOT_DIR}; python -m pip install -e python
 
 lint-python:
 	cd ${ROOT_DIR}/python ; mypy feast_spark/

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,7 @@ compile-protos-python: install-python-ci-dependencies
 	cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. --python_out=../python/ --grpc_python_out=../python/ --mypy_out=../python/ feast_spark/third_party/grpc/health/v1/*.proto
 
 # Supports feast-dev repo master branch
-<<<<<<< HEAD
 install-python: compile-protos-python
-=======
-install-python: install-python-ci-dependencies
-	cd ${SUBMODULE_DIR}; make install-python
->>>>>>> Revert command
 	cd ${ROOT_DIR}; python -m pip install -e python
 
 lint-python:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ compile-protos-python: install-python-ci-dependencies
 # Supports feast-dev repo master branch
 install-python: compile-protos-python
 	cd ${ROOT_DIR}; python -m pip install -e python
+	cd ${SUBMODULE_DIR}; make install-python
 
 lint-python:
 	cd ${ROOT_DIR}/python ; mypy feast_spark/

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -342,7 +342,9 @@ class Client:
             return list_jobs(include_terminated, self, project, table_name)
         else:
             request = ListJobsRequest(
-                include_terminated=include_terminated, project=project, table_name=cast(str, table_name)
+                include_terminated=include_terminated,
+                project=project,
+                table_name=cast(str, table_name),
             )
             response = self._job_service.ListJobs(request)
             return [

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -324,13 +324,25 @@ class Client:
             )
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str] = None
+        self,
+        include_terminated: bool,
+        project: Optional[str] = None,
+        table_name: Optional[str] = None,
     ) -> List[SparkJob]:
+        """
+        List ingestion jobs currently running in Feast.
+        Args:
+            include_terminated: Flag to include terminated jobs or not
+            project: Optionally specify the project to use as filter when retrieving jobs
+            table_name: Optionally specify name of feature table to use as filter when retrieving jobs
+        Returns:
+            List of SparkJob ingestion jobs.
+        """
         if not self._use_job_service:
-            return list_jobs(include_terminated, self, table_name)
+            return list_jobs(include_terminated, self, project, table_name)
         else:
             request = ListJobsRequest(
-                include_terminated=include_terminated, table_name=cast(str, table_name)
+                include_terminated=include_terminated, project=project, table_name=cast(str, table_name)
             )
             response = self._job_service.ListJobs(request)
             return [

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -194,6 +194,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
         """List all types of jobs"""
         jobs = list_jobs(
             include_terminated=request.include_terminated,
+            project=request.project,
             table_name=request.table_name,
             client=self.client,
         )

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -359,6 +359,9 @@ class IngestionJobParameters(SparkJobParameters):
             else None
         )
 
+    def get_project(self) -> str:
+        return self._feature_table["project"]
+
     def get_feature_table_name(self) -> str:
         return self._feature_table["name"]
 
@@ -609,6 +612,9 @@ class JobLauncher(abc.ABC):
 
     @abc.abstractmethod
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str]
+        self,
+        include_terminated: bool,
+        project: Optional[str],
+        table_name: Optional[str],
     ) -> List[SparkJob]:
         raise NotImplementedError

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -322,11 +322,14 @@ def start_stream_to_online_ingestion(
 
 
 def list_jobs(
-    include_terminated: bool, client: "Client", table_name: Optional[str] = None
+    include_terminated: bool,
+    client: "Client",
+    project: Optional[str] = None,
+    table_name: Optional[str] = None,
 ) -> List[SparkJob]:
     launcher = resolve_launcher(client.config)
     return launcher.list_jobs(
-        include_terminated=include_terminated, table_name=table_name
+        include_terminated=include_terminated, table_name=table_name, project=project
     )
 
 

--- a/python/feast_spark/pyspark/launchers/aws/emr.py
+++ b/python/feast_spark/pyspark/launchers/aws/emr.py
@@ -111,12 +111,16 @@ class EmrBatchIngestionJob(EmrJobMixin, BatchIngestionJob):
     Ingestion job result for a EMR cluster
     """
 
-    def __init__(self, emr_client, job_ref: EmrJobRef, table_name: str):
+    def __init__(self, emr_client, job_ref: EmrJobRef, project: str, table_name: str):
         super().__init__(emr_client, job_ref)
+        self._project = project
         self._table_name = table_name
 
     def get_feature_table(self) -> str:
         return self._table_name
+
+    def get_project(self) -> str:
+        return self._project
 
 
 class EmrStreamIngestionJob(EmrJobMixin, StreamIngestionJob):
@@ -124,9 +128,17 @@ class EmrStreamIngestionJob(EmrJobMixin, StreamIngestionJob):
     Ingestion streaming job for a EMR cluster
     """
 
-    def __init__(self, emr_client, job_ref: EmrJobRef, job_hash: str, table_name: str):
+    def __init__(
+        self,
+        emr_client,
+        job_ref: EmrJobRef,
+        job_hash: str,
+        project: str,
+        table_name: str,
+    ):
         super().__init__(emr_client, job_ref)
         self._job_hash = job_hash
+        self._project = project
         self._table_name = table_name
 
     def get_hash(self) -> str:
@@ -271,15 +283,19 @@ class EmrClusterLauncher(JobLauncher):
             self._staging_location, ingestion_job_params.get_main_file_path()
         )
         step = _sync_offline_to_online_step(
-            jar_s3_path,
-            ingestion_job_params.get_feature_table_name(),
+            jar_path=jar_s3_path,
+            project=ingestion_job_params.get_project(),
+            feature_table_name=ingestion_job_params.get_feature_table_name(),
             args=ingestion_job_params.get_arguments(),
         )
 
         job_ref = self._submit_emr_job(step)
 
         return EmrBatchIngestionJob(
-            self._emr_client(), job_ref, ingestion_job_params.get_feature_table_name()
+            self._emr_client(),
+            job_ref,
+            ingestion_job_params.get_project(),
+            ingestion_job_params.get_feature_table_name(),
         )
 
     def start_stream_to_online_ingestion(
@@ -305,9 +321,10 @@ class EmrClusterLauncher(JobLauncher):
         job_hash = ingestion_job_params.get_job_hash()
 
         step = _stream_ingestion_step(
-            jar_s3_path,
-            extra_jar_paths,
-            ingestion_job_params.get_feature_table_name(),
+            jar_path=jar_s3_path,
+            extra_jar_paths=extra_jar_paths,
+            project=ingestion_job_params.get_project(),
+            feature_table_name=ingestion_job_params.get_feature_table_name(),
             args=ingestion_job_params.get_arguments(),
             job_hash=job_hash,
         )
@@ -318,6 +335,7 @@ class EmrClusterLauncher(JobLauncher):
             self._emr_client(),
             job_ref,
             job_hash,
+            ingestion_job_params.get_project(),
             ingestion_job_params.get_feature_table_name(),
         )
 
@@ -330,15 +348,20 @@ class EmrClusterLauncher(JobLauncher):
                 output_file_uri=job_info.output_file_uri,
             )
         elif job_info.job_type == OFFLINE_TO_ONLINE_JOB_TYPE:
+            project = job_info.project if job_info.project else ""
             table_name = job_info.table_name if job_info.table_name else ""
+            assert project is not None
             assert table_name is not None
             return EmrBatchIngestionJob(
                 emr_client=self._emr_client(),
                 job_ref=job_info.job_ref,
+                project=project,
                 table_name=table_name,
             )
         elif job_info.job_type == STREAM_TO_ONLINE_JOB_TYPE:
+            project = job_info.project if job_info.project else ""
             table_name = job_info.table_name if job_info.table_name else ""
+            assert project is not None
             assert table_name is not None
             # job_hash must not be None for stream ingestion jobs
             assert job_info.job_hash is not None
@@ -346,6 +369,7 @@ class EmrClusterLauncher(JobLauncher):
                 emr_client=self._emr_client(),
                 job_ref=job_info.job_ref,
                 job_hash=job_info.job_hash,
+                project=project,
                 table_name=table_name,
             )
         else:
@@ -353,7 +377,10 @@ class EmrClusterLauncher(JobLauncher):
             raise ValueError(f"Unknown job type {job_info.job_type}")
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str] = None
+        self,
+        include_terminated: bool,
+        project: Optional[str] = None,
+        table_name: Optional[str] = None,
     ) -> List[SparkJob]:
         """
         Find EMR job by a string id.
@@ -369,6 +396,7 @@ class EmrClusterLauncher(JobLauncher):
         jobs = _list_jobs(
             emr_client=self._emr_client(),
             job_type=None,
+            project=None,
             table_name=table_name,
             active_only=not include_terminated,
         )
@@ -389,6 +417,7 @@ class EmrClusterLauncher(JobLauncher):
         jobs = _list_jobs(
             emr_client=self._emr_client(),
             job_type=None,
+            project=None,
             table_name=None,
             active_only=False,
         )

--- a/python/feast_spark/pyspark/launchers/aws/emr_utils.py
+++ b/python/feast_spark/pyspark/launchers/aws/emr_utils.py
@@ -95,7 +95,7 @@ def _upload_jar(jar_s3_prefix: str, jar_path: str) -> str:
 
 
 def _sync_offline_to_online_step(
-    jar_path: str, feature_table_name: str, args: List[str],
+    jar_path: str, project: str, feature_table_name: str, args: List[str],
 ) -> Dict[str, Any]:
 
     return {
@@ -106,6 +106,7 @@ def _sync_offline_to_online_step(
                     "Key": "feast.step_metadata.job_type",
                     "Value": OFFLINE_TO_ONLINE_JOB_TYPE,
                 },
+                {"Key": "feast.step_metadata.project", "Value": project},
                 {
                     "Key": "feast.step_metadata.offline_to_online.table_name",
                     "Value": feature_table_name,
@@ -141,19 +142,25 @@ class JobInfo(NamedTuple):
     job_ref: EmrJobRef
     job_type: str
     state: str
+    project: str
     table_name: Optional[str]
     output_file_uri: Optional[str]
     job_hash: Optional[str]
 
 
 def _list_jobs(
-    emr_client, job_type: Optional[str], table_name: Optional[str], active_only=True
+    emr_client,
+    job_type: Optional[str],
+    project: Optional[str],
+    table_name: Optional[str],
+    active_only=True,
 ) -> List[JobInfo]:
     """
     List Feast EMR jobs.
 
     Args:
         job_type: optional filter by job type
+        project: optional filter by project
         table_name: optional filter by table name
         active_only: filter only for "active" jobs, that is the ones that are running or pending, not terminated
 
@@ -180,6 +187,8 @@ def _list_jobs(
                     if "feast.step_metadata.job_type" not in props:
                         continue
 
+                    step_project = props.get("feast.step_metadata.project")
+
                     step_table_name = props.get(
                         "feast.step_metadata.stream_to_online.table_name"
                     ) or props.get("feast.step_metadata.offline_to_online.table_name")
@@ -190,6 +199,9 @@ def _list_jobs(
                     )
 
                     job_hash = props.get("feast.step_metadata.job_hash")
+
+                    if project and step_project != project:
+                        continue
 
                     if table_name and step_table_name != table_name:
                         continue
@@ -202,6 +214,7 @@ def _list_jobs(
                             job_type=step_job_type,
                             job_ref=EmrJobRef(cluster_id, step["Id"]),
                             state=step["Status"]["State"],
+                            project=step_project,
                             table_name=step_table_name,
                             output_file_uri=output_file_uri,
                             job_hash=job_hash,
@@ -334,6 +347,7 @@ def _historical_retrieval_step(
 def _stream_ingestion_step(
     jar_path: str,
     extra_jar_paths: List[str],
+    project: str,
     feature_table_name: str,
     args: List[str],
     job_hash: str,
@@ -352,6 +366,7 @@ def _stream_ingestion_step(
                     "Key": "feast.step_metadata.job_type",
                     "Value": STREAM_TO_ONLINE_JOB_TYPE,
                 },
+                {"Key": "feast.step_metadata.project", "Value": project},
                 {
                     "Key": "feast.step_metadata.stream_to_online.table_name",
                     "Value": feature_table_name,

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -60,8 +60,8 @@ def _truncate_label(label: str) -> str:
     return label[:63]
 
 
-def _generate_table_hash(table_name: str) -> str:
-    return hashlib.md5(table_name.encode()).hexdigest()
+def _generate_project_table_hash(project: str, table_name: str) -> str:
+    return hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
 
 
 class KubernetesJobMixin:
@@ -340,8 +340,9 @@ class KubernetesJobLauncher(JobLauncher):
                 LABEL_FEATURE_TABLE: _truncate_label(
                     ingestion_job_params.get_feature_table_name()
                 ),
-                LABEL_FEATURE_TABLE_HASH: _generate_table_hash(
-                    ingestion_job_params.get_feature_table_name()
+                LABEL_FEATURE_TABLE_HASH: _generate_project_table_hash(
+                    ingestion_job_params.get_project(),
+                    ingestion_job_params.get_feature_table_name(),
                 ),
             },
         )
@@ -391,8 +392,9 @@ class KubernetesJobLauncher(JobLauncher):
                 LABEL_FEATURE_TABLE: _truncate_label(
                     ingestion_job_params.get_feature_table_name()
                 ),
-                LABEL_FEATURE_TABLE_HASH: _generate_table_hash(
-                    ingestion_job_params.get_feature_table_name()
+                LABEL_FEATURE_TABLE_HASH: _generate_project_table_hash(
+                    ingestion_job_params.get_project(),
+                    ingestion_job_params.get_feature_table_name(),
                 ),
             },
         )
@@ -411,11 +413,14 @@ class KubernetesJobLauncher(JobLauncher):
             return self._job_from_job_info(job_info)
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str] = None
+        self,
+        include_terminated: bool,
+        project: Optional[str] = None,
+        table_name: Optional[str] = None,
     ) -> List[SparkJob]:
         return [
             self._job_from_job_info(job)
-            for job in _list_jobs(self._api, self._namespace, table_name)
+            for job in _list_jobs(self._api, self._namespace, project, table_name)
             if include_terminated
             or job.state not in (SparkJobStatus.COMPLETED, SparkJobStatus.FAILED)
         ]

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -1,4 +1,3 @@
-import hashlib
 import random
 import string
 import time
@@ -37,6 +36,7 @@ from .k8s_utils import (
     STREAM_TO_ONLINE_JOB_TYPE,
     JobInfo,
     _cancel_job_by_id,
+    _generate_project_table_hash,
     _get_api,
     _get_job_by_id,
     _list_jobs,
@@ -58,10 +58,6 @@ def _generate_job_id() -> str:
 
 def _truncate_label(label: str) -> str:
     return label[:63]
-
-
-def _generate_project_table_hash(project: str, table_name: str) -> str:
-    return hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
 
 
 class KubernetesJobMixin:

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -225,13 +225,16 @@ def _submit_job(api: CustomObjectsApi, resource, namespace: str) -> JobInfo:
 
 
 def _list_jobs(
-    api: CustomObjectsApi, namespace: str, table_name: Optional[str] = None
+    api: CustomObjectsApi,
+    namespace: str,
+    project: Optional[str] = None,
+    table_name: Optional[str] = None,
 ) -> List[JobInfo]:
     result = []
 
     # Batch, Streaming Ingestion jobs
-    if table_name:
-        table_name_hash = hashlib.md5(table_name.encode()).hexdigest()
+    if project and table_name:
+        table_name_hash = hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
         response = api.list_namespaced_custom_object(
             **_crd_args(namespace),
             label_selector=f"{LABEL_FEATURE_TABLE_HASH}={table_name_hash}",

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "_prepare_job_resource",
     "_list_jobs",
     "_get_job_by_id",
+    "_generate_project_table_hash",
     "STREAM_TO_ONLINE_JOB_TYPE",
     "OFFLINE_TO_ONLINE_JOB_TYPE",
     "HISTORICAL_RETRIEVAL_JOB_TYPE",
@@ -100,6 +101,10 @@ def _add_keys(resource: Dict[str, Any], path: Tuple[str, ...], items: Dict[str, 
         if v is not None:
             obj[k] = v
     return resource
+
+
+def _generate_project_table_hash(project: str, table_name: str) -> str:
+    return hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
 
 
 def _job_id_to_resource_name(job_id: str) -> str:
@@ -234,7 +239,7 @@ def _list_jobs(
 
     # Batch, Streaming Ingestion jobs
     if project and table_name:
-        table_name_hash = hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
+        table_name_hash = _generate_project_table_hash(project, table_name)
         response = api.list_namespaced_custom_object(
             **_crd_args(namespace),
             label_selector=f"{LABEL_FEATURE_TABLE_HASH}={table_name_hash}",

--- a/python/feast_spark/pyspark/launchers/standalone/local.py
+++ b/python/feast_spark/pyspark/launchers/standalone/local.py
@@ -356,7 +356,10 @@ class StandaloneClusterLauncher(JobLauncher):
         return global_job_cache.get_job_by_id(job_id)
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str]
+        self,
+        include_terminated: bool,
+        project: Optional[str],
+        table_name: Optional[str],
     ) -> List[SparkJob]:
         if include_terminated is True:
             return global_job_cache.list_jobs()

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -234,7 +234,7 @@ def test_list_jobs_long_table_name(
     )
     all_job_ids = [
         job.get_id()
-        for job in feast_spark.Client(feast_client).list_jobs(
+        for job in feast_spark_client.list_jobs(
             include_terminated=True, project="default", table_name=feature_table.name
         )
     ]

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -234,8 +234,8 @@ def test_list_jobs_long_table_name(
     )
     all_job_ids = [
         job.get_id()
-        for job in feast_spark_client.list_jobs(
-            include_terminated=True, table_name=feature_table.name
+        for job in feast_spark.Client(feast_client).list_jobs(
+            include_terminated=True, project="default", table_name=feature_table.name
         )
     ]
     assert job.get_id() in all_job_ids


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, list jobs api does not support project filter, and this may result in potential feature table name collisions across different feast projects.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now list jobs using project as a filter.
```
