### PR TITLE
Configurable retry for failed jobs (JobService Control Loop)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,3 +60,14 @@ jobs:
         run: make install-python-ci-dependencies
       - name: Lint python
         run: make lint-python
+
+  unit-test-python:
+    runs-on: [ubuntu-latest]
+    needs: lint-python
+    container: gcr.io/kf-feast/feast-ci:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install python
+        run: make install-python
+      - name: Test python
+        run: make test-python

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,6 +62,10 @@ jobs:
           java-version: '11'
           java-package: jdk
           architecture: x64
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+          architecture: 'x64'
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,26 @@ jobs:
       - name: Lint java
         run: make lint-java
 
+  test-java:
+    runs-on: ubuntu-latest
+    needs: lint-java
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          java-package: jdk
+          architecture: x64
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-ut-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-ut-maven-
+      - name: Test java
+        run: make test-java
+
   lint-python:
     container: gcr.io/kf-feast/feast-ci:latest
     runs-on: [ubuntu-latest]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ format-java:
 lint-java:
 	cd spark/ingestion && ${MVN} --no-transfer-progress spotless:check
 
+test-java:
+	${MVN} --no-transfer-progress clean verify
+
 # Python
 
 format-python:

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,17 @@ install-python: compile-protos-python
 	cd ${ROOT_DIR}; python -m pip install -e python
 
 lint-python:
-	cd ${ROOT_DIR}/python ; mypy feast_spark/
-	cd ${ROOT_DIR}/python ; isort feast_spark/ --check-only
-	cd ${ROOT_DIR}/python ; flake8 feast_spark/
-	cd ${ROOT_DIR}/python ; black --check feast_spark
+	cd ${ROOT_DIR}/python ; mypy feast_spark/ tests/
+	cd ${ROOT_DIR}/python ; isort feast_spark/ tests/ --check-only
+	cd ${ROOT_DIR}/python ; flake8 feast_spark/ tests/
+	cd ${ROOT_DIR}/python ; black --check feast_spark tests
 	cd ${ROOT_DIR}/tests; mypy e2e
 	cd ${ROOT_DIR}/tests; isort e2e --check-only
 	cd ${ROOT_DIR}/tests; flake8 e2e
 	cd ${ROOT_DIR}/tests; black --check e2e
+
+test-python:
+	pytest --verbose --color=yes python/tests
 
 build-local-test-docker:
 	docker build -t feast:local -f infra/docker/tests/Dockerfile .

--- a/infra/scripts/k8s-common-functions.sh
+++ b/infra/scripts/k8s-common-functions.sh
@@ -81,7 +81,7 @@ function helm_install {
 
           kubectl -n "$NAMESPACE" get pods
 
-          readarray -t CRASHED_PODS < <(kubectl -n "$NAMESPACE" get pods --no-headers=true | grep "$RELEASE" | awk '{if ($2 == "0/1") { print $1 } }')
+          readarray -t CRASHED_PODS < <(kubectl -n "$NAMESPACE" get pods --no-headers=true | grep "${FEAST_RELEASE_NAME:-feast-release}" | awk '{if ($2 == "0/1") { print $1 } }')
           echo "Crashed pods: ${CRASHED_PODS[*]}"
 
           for POD in "${CRASHED_PODS[@]}"; do

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>feast-spark</artifactId>
     <name>Feast Spark</name>
+
+    <groupId>dev.feast</groupId>
+    <artifactId>feast-spark-parent</artifactId>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -12,6 +15,34 @@
 
     <properties>
         <revision>0.1.0-SNAPSHOT</revision>
+        <scala.version>2.12</scala.version>
+        <scala.fullVersion>${scala.version}.12</scala.fullVersion>
+        <spark.version>3.0.1</spark.version>
+        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <protobuf.version>3.12.2</protobuf.version>
+        <commons.lang3.version>3.10</commons.lang3.version>
+
+        <license.content><![CDATA[
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-$YEAR The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+]]>
+        </license.content>
     </properties>
+
 
 </project>

--- a/python/feast_spark/cli.py
+++ b/python/feast_spark/cli.py
@@ -1,6 +1,45 @@
+import logging.config
+
 import click
 
 from feast_spark.job_service import start_job_service
+
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "standard": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"},
+        },
+        "handlers": {
+            "debug": {
+                "level": "DEBUG",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+            "standard": {
+                "level": "WARNING",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+            },
+        },
+        "loggers": {
+            "": {"handlers": ["standard"], "level": "WARNING", "propagate": False},
+            "feast_spark": {
+                "handlers": ["debug", "standard"],
+                "level": "INFO",
+                "propagate": False,
+            },
+            "feast": {
+                "handlers": ["debug", "standard"],
+                "level": "INFO",
+                "propagate": False,
+            },
+        },
+    }
+)
 
 
 @click.group()

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -17,7 +17,6 @@ from feast.staging.entities import (
     stage_entities_to_fs,
     table_reference_from_string,
 )
-
 from feast_spark.api.JobService_pb2 import (
     GetHistoricalFeaturesRequest,
     GetJobRequest,

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 import feast
 from feast.config import Config
+from feast.constants import ConfigOptions as feast_opt
 from feast.data_source import BigQuerySource, FileSource
 from feast.grpc.grpc import create_grpc_channel
 from feast.staging.entities import (
@@ -16,6 +17,7 @@ from feast.staging.entities import (
     stage_entities_to_fs,
     table_reference_from_string,
 )
+
 from feast_spark.api.JobService_pb2 import (
     GetHistoricalFeaturesRequest,
     GetJobRequest,
@@ -84,10 +86,10 @@ class Client:
             channel = create_grpc_channel(
                 url=self.config.get(opt.JOB_SERVICE_URL),
                 enable_ssl=self.config.getboolean(opt.JOB_SERVICE_ENABLE_SSL),
-                enable_auth=self.config.getboolean(opt.ENABLE_AUTH),
+                enable_auth=self.config.getboolean(feast_opt.ENABLE_AUTH),
                 ssl_server_cert_path=self.config.get(opt.JOB_SERVICE_SERVER_SSL_CERT),
                 auth_metadata_plugin=self._feast._auth_metadata,
-                timeout=self.config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+                timeout=self.config.getint(feast_opt.GRPC_CONNECTION_TIMEOUT),
             )
             self._job_service_service_stub = JobServiceStub(channel)
         return self._job_service_service_stub

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -1,3 +1,4 @@
+import configparser
 import os
 import uuid
 from datetime import datetime
@@ -8,7 +9,6 @@ import pandas as pd
 
 import feast
 from feast.config import Config
-from feast.constants import ConfigOptions as opt
 from feast.data_source import BigQuerySource, FileSource
 from feast.grpc.grpc import create_grpc_channel
 from feast.staging.entities import (
@@ -24,6 +24,7 @@ from feast_spark.api.JobService_pb2 import (
     StartStreamToOnlineIngestionJobRequest,
 )
 from feast_spark.api.JobService_pb2_grpc import JobServiceStub
+from feast_spark.constants import ConfigOptions as opt
 from feast_spark.pyspark.abc import RetrievalJob, SparkJob
 from feast_spark.pyspark.launcher import (
     get_job_by_id,
@@ -45,6 +46,10 @@ class Client:
     _feast: feast.Client
 
     def __init__(self, feast_client: feast.Client):
+        feast_client._config._config.read_dict(
+            {configparser.DEFAULTSECT: opt().defaults()}
+        )
+
         self._feast = feast_client
         self._job_service_stub: Optional[JobServiceStub] = None
 
@@ -343,7 +348,7 @@ class Client:
         else:
             request = ListJobsRequest(
                 include_terminated=include_terminated,
-                project=project,
+                project=cast(str, project),
                 table_name=cast(str, table_name),
             )
             response = self._job_service.ListJobs(request)

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -1,0 +1,150 @@
+from typing import Optional
+
+from feast.constants import ConfigMeta
+
+
+class ConfigOptions(metaclass=ConfigMeta):
+    #: Default Feast Job Service URL
+    JOB_SERVICE_URL: Optional[str] = None
+
+    #: Enable or disable TLS/SSL to Feast Job Service
+    JOB_SERVICE_ENABLE_SSL: str = "False"
+
+    #: Path to certificate(s) to secure connection to Feast Job Service
+    JOB_SERVICE_SERVER_SSL_CERT: str = ""
+
+    #: Enable or disable control loop for Feast Job Service
+    JOB_SERVICE_ENABLE_CONTROL_LOOP: str = "False"
+
+    #: If set to True, Control Loop will try to start failed streaming jobss
+    JOB_SERVICE_RETRY_FAILED_JOBS: str = "False"
+
+    #: Pause in seconds between starting new jobs in Control Loop
+    JOB_SERVICE_PAUSE_BETWEEN_JOBS: str = "5"
+
+    #: Default timeout when running batch ingestion
+    BATCH_INGESTION_PRODUCTION_TIMEOUT: str = "120"
+
+    #: Time to wait for historical feature requests before timing out.
+    BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS: str = "600"
+
+    #: Endpoint URL for S3 storage_client
+    S3_ENDPOINT_URL: Optional[str] = None
+
+    #: Account name for Azure blob storage_client
+    AZURE_BLOB_ACCOUNT_NAME: Optional[str] = None
+
+    #: Account access key for Azure blob storage_client
+    AZURE_BLOB_ACCOUNT_ACCESS_KEY: Optional[str] = None
+
+    #: Spark Job launcher. The choice of storage is connected to the choice of SPARK_LAUNCHER.
+    #:
+    #: Options: "standalone", "dataproc", "emr"
+    SPARK_LAUNCHER: Optional[str] = None
+
+    #: Feast Spark Job ingestion jobs staging location. The choice of storage is connected to the choice of SPARK_LAUNCHER.
+    #:
+    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file:///data/subfolder/
+    SPARK_STAGING_LOCATION: Optional[str] = None
+
+    #: Feast Spark Job ingestion jar file. The choice of storage is connected to the choice of SPARK_LAUNCHER.
+    #:
+    #: Eg. "dataproc" (http and gs), "emr" (http and s3), "standalone" (http and file)
+    SPARK_INGESTION_JAR: str = "https://storage.googleapis.com/feast-jobs/spark/ingestion/feast-ingestion-spark-develop.jar"
+
+    #: Spark resource manager master url
+    SPARK_STANDALONE_MASTER: str = "local[*]"
+
+    #: Directory where Spark is installed
+    SPARK_HOME: Optional[str] = None
+
+    #: The project id where the materialized view of BigQuerySource is going to be created
+    #: by default, use the same project where view is located
+    SPARK_BQ_MATERIALIZATION_PROJECT: Optional[str] = None
+
+    #: The dataset id where the materialized view of BigQuerySource is going to be created
+    #: by default, use the same dataset where view is located
+    SPARK_BQ_MATERIALIZATION_DATASET: Optional[str] = None
+
+    #: Dataproc cluster to run Feast Spark Jobs in
+    DATAPROC_CLUSTER_NAME: Optional[str] = None
+
+    #: Project of Dataproc cluster
+    DATAPROC_PROJECT: Optional[str] = None
+
+    #: Region of Dataproc cluster
+    DATAPROC_REGION: Optional[str] = None
+
+    #: No. of executor instances for Dataproc cluster
+    DATAPROC_EXECUTOR_INSTANCES = "2"
+
+    #: No. of executor cores for Dataproc cluster
+    DATAPROC_EXECUTOR_CORES = "2"
+
+    #: No. of executor memory for Dataproc cluster
+    DATAPROC_EXECUTOR_MEMORY = "2g"
+
+    # namespace to use for Spark jobs launched using k8s spark operator
+    SPARK_K8S_NAMESPACE = "default"
+
+    # expect k8s spark operator to be running in the same cluster as Feast
+    SPARK_K8S_USE_INCLUSTER_CONFIG = "True"
+
+    # SparkApplication resource template
+    SPARK_K8S_JOB_TEMPLATE_PATH = None
+
+    #: File format of historical retrieval features
+    HISTORICAL_FEATURE_OUTPUT_FORMAT: str = "parquet"
+
+    #: File location of historical retrieval features
+    HISTORICAL_FEATURE_OUTPUT_LOCATION: Optional[str] = None
+
+    #: Default Redis host
+    REDIS_HOST: str = "localhost"
+
+    #: Default Redis port
+    REDIS_PORT: str = "6379"
+
+    #: Enable or disable TLS/SSL to Redis
+    REDIS_SSL: str = "False"
+
+    #: Enable or disable StatsD
+    STATSD_ENABLED: str = "False"
+
+    #: Default StatsD port
+    STATSD_HOST: Optional[str] = None
+
+    #: Default StatsD port
+    STATSD_PORT: Optional[str] = None
+
+    #: Ingestion Job DeadLetter Destination. The choice of storage is connected to the choice of SPARK_LAUNCHER.
+    #:
+    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file:///data/subfolder/
+    DEADLETTER_PATH: str = ""
+
+    #: ProtoRegistry Address (currently only Stencil Server is supported as registry)
+    #: https://github.com/gojekfarm/stencil
+    STENCIL_URL: str = ""
+
+    #: If set to true rows that do not pass custom validation (see feast.contrib.validation)
+    #: won't be saved to Online Storage
+    INGESTION_DROP_INVALID_ROWS: str = "False"
+
+    #: EMR cluster to run Feast Spark Jobs in
+    EMR_CLUSTER_ID: Optional[str] = None
+
+    #: Region of EMR cluster
+    EMR_REGION: Optional[str] = None
+
+    #: Template path of EMR cluster
+    EMR_CLUSTER_TEMPLATE_PATH: Optional[str] = None
+
+    #: Log path of EMR cluster
+    EMR_LOG_LOCATION: Optional[str] = None
+
+    def defaults(self):
+        return {
+            k: getattr(self, k)
+            for k in self.__config_keys__
+            if getattr(self, k) is not None
+        }

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from urllib.parse import urlparse, urlunparse
 
 from feast.config import Config
-from feast.constants import ConfigOptions as opt
 from feast.data_format import ParquetFormat
 from feast.data_source import BigQuerySource, DataSource, FileSource, KafkaSource
 from feast.feature_table import FeatureTable
 from feast.staging.entities import create_bq_view_of_joined_features_and_entities
 from feast.staging.storage_client import get_staging_client
 from feast.value_type import ValueType
+from feast_spark.constants import ConfigOptions as opt
 from feast_spark.pyspark.abc import (
     BatchIngestionJob,
     BatchIngestionJobParameters,

--- a/python/tests/test_streaming_job_scheduling.py
+++ b/python/tests/test_streaming_job_scheduling.py
@@ -1,0 +1,214 @@
+import copy
+import hashlib
+import json
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from feast import Client as FeastClient
+from feast.config import Config
+from feast.data_format import AvroFormat
+from feast.data_source import KafkaSource
+from feast.feature_table import FeatureTable
+from feast_spark.client import Client
+from feast_spark.job_service import ensure_stream_ingestion_jobs
+from feast_spark.pyspark.abc import SparkJobStatus, StreamIngestionJob
+from feast_spark.pyspark.launcher import _feature_table_to_argument, _source_to_argument
+
+
+@pytest.fixture
+def feast_client():
+    c = FeastClient(job_service_pause_between_jobs=0)
+    c.list_projects = Mock(return_value=["default"])
+    c.list_feature_tables = Mock()
+
+    yield c
+
+
+@pytest.fixture
+def spark_client(feast_client):
+    c = Client(feast_client)
+    c.list_jobs = Mock()
+    c.start_stream_to_online_ingestion = Mock()
+
+    yield c
+
+
+@pytest.fixture
+def feature_table():
+    return FeatureTable(
+        name="ft",
+        entities=[],
+        features=[],
+        stream_source=KafkaSource(
+            topic="t",
+            bootstrap_servers="",
+            message_format=AvroFormat(""),
+            event_timestamp_column="",
+        ),
+    )
+
+
+class SimpleStreamingIngestionJob(StreamIngestionJob):
+    def __init__(self, id: str, feature_table: FeatureTable, status: SparkJobStatus):
+        self._id = id
+        self._feature_table = feature_table
+        self._status = status
+        self._hash = hash
+
+    def get_hash(self) -> str:
+        source = _source_to_argument(self._feature_table.stream_source, Config())
+        feature_table = _feature_table_to_argument(None, "default", self._feature_table)  # type: ignore
+
+        job_json = json.dumps(
+            {"source": source, "feature_table": feature_table}, sort_keys=True,
+        )
+        return hashlib.md5(job_json.encode()).hexdigest()
+
+    def get_feature_table(self) -> str:
+        return self._feature_table.name
+
+    def get_id(self) -> str:
+        return self._id
+
+    def get_status(self) -> SparkJobStatus:
+        return self._status
+
+    def cancel(self):
+        self._status = SparkJobStatus.COMPLETED
+
+    def get_start_time(self) -> datetime:
+        pass
+
+
+def test_new_job_creation(spark_client, feature_table):
+    """ No job existed prior to call """
+
+    spark_client.feature_store.list_feature_tables.return_value = [feature_table]
+    spark_client.list_jobs.return_value = []
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+        feature_table, [], project="default"
+    )
+
+
+def test_no_changes(spark_client, feature_table):
+    """ Feature Table spec is the same """
+
+    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.IN_PROGRESS)
+
+    spark_client.feature_store.list_feature_tables.return_value = [feature_table]
+    spark_client.list_jobs.return_value = [job]
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    assert job.get_status() == SparkJobStatus.IN_PROGRESS
+    spark_client.start_stream_to_online_ingestion.assert_not_called()
+
+
+def test_update_existing_job(spark_client, feature_table):
+    """ Feature Table spec was updated """
+
+    new_ft = copy.deepcopy(feature_table)
+    new_ft.stream_source._kafka_options.topic = "new_t"
+    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.IN_PROGRESS)
+
+    spark_client.feature_store.list_feature_tables.return_value = [new_ft]
+    spark_client.list_jobs.return_value = [job]
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    assert job.get_status() == SparkJobStatus.COMPLETED
+    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+        new_ft, [], project="default"
+    )
+
+
+def test_not_cancelling_starting_job(spark_client, feature_table):
+    """ Feature Table spec was updated but previous version is still starting """
+
+    new_ft = copy.deepcopy(feature_table)
+    new_ft.stream_source._kafka_options.topic = "new_t"
+    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.STARTING)
+
+    spark_client.feature_store.list_feature_tables.return_value = [new_ft]
+    spark_client.list_jobs.return_value = [job]
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    assert job.get_status() == SparkJobStatus.STARTING
+    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+        new_ft, [], project="default"
+    )
+
+
+def test_not_retrying_failed_job(spark_client, feature_table):
+    """ Job has failed on previous try """
+
+    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.FAILED)
+
+    spark_client.feature_store.list_feature_tables.return_value = [feature_table]
+    spark_client.list_jobs.return_value = [job]
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    spark_client.list_jobs.assert_called_once_with(include_terminated=True)
+    assert job.get_status() == SparkJobStatus.FAILED
+    spark_client.start_stream_to_online_ingestion.assert_not_called()
+
+
+def test_restarting_completed_job(spark_client, feature_table):
+    """ Job has succesfully finished on previous try """
+    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.COMPLETED)
+
+    spark_client.feature_store.list_feature_tables.return_value = [feature_table]
+    spark_client.list_jobs.return_value = [job]
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+        feature_table, [], project="default"
+    )
+
+
+def test_stopping_running_job(spark_client, feature_table):
+    """ Streaming source was deleted """
+    new_ft = copy.deepcopy(feature_table)
+    new_ft.stream_source = None
+
+    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.IN_PROGRESS)
+
+    spark_client.feature_store.list_feature_tables.return_value = [new_ft]
+    spark_client.list_jobs.return_value = [job]
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    assert job.get_status() == SparkJobStatus.COMPLETED
+    spark_client.start_stream_to_online_ingestion.assert_not_called()
+
+
+def test_restarting_failed_jobs(feature_table):
+    """ If configured - restart failed jobs """
+
+    feast_client = FeastClient(
+        job_service_pause_between_jobs=0, job_service_retry_failed_jobs=True
+    )
+    feast_client.list_projects = Mock(return_value=["default"])
+    feast_client.list_feature_tables = Mock()
+
+    spark_client = Client(feast_client)
+    spark_client.list_jobs = Mock()
+    spark_client.start_stream_to_online_ingestion = Mock()
+
+    spark_client.feature_store.list_feature_tables.return_value = [feature_table]
+    spark_client.list_jobs.return_value = []
+
+    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+
+    spark_client.list_jobs.assert_called_once_with(include_terminated=False)
+    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+        feature_table, [], project="default"
+    )

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -20,42 +20,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>dev.feast</groupId>
+        <artifactId>feast-spark-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
     <name>Feast Spark Ingestion</name>
     <artifactId>feast-ingestion-spark</artifactId>
-
-    <groupId>dev.feast</groupId>
     <version>${revision}</version>
 
-    <properties>
-        <scala.version>2.12</scala.version>
-        <scala.fullVersion>${scala.version}.12</scala.fullVersion>
-        <spark.version>3.0.1</spark.version>
-        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
-        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <protobuf.version>3.12.2</protobuf.version>
-        <revision>0.1.0-SNAPSHOT</revision>
-        <commons.lang3.version>3.10</commons.lang3.version>
-
-        <license.content><![CDATA[
-/*
- * SPDX-License-Identifier: Apache-2.0
- * Copyright 2018-$YEAR The Feast Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-]]>
-        </license.content>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -214,7 +214,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>1.26.1</version>
+                <version>2.8.1</version>
                 <configuration>
                     <java>
                         <licenseHeader>


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
In some cases it's better to rely on launcher to retry failed streaming jobs instead of infinitely spawn new jobs. This PR makes retry logic configurable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added configuration option JOB_SERVICE_RETRY_FAILED_JOBS. False by default
```
