### PR TITLE
Capture case where only project is provided

### DIFF
--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -30,12 +30,14 @@ from .k8s_utils import (
     HISTORICAL_RETRIEVAL_JOB_TYPE,
     LABEL_FEATURE_TABLE,
     LABEL_FEATURE_TABLE_HASH,
+    LABEL_PROJECT_HASH,
     METADATA_JOBHASH,
     METADATA_OUTPUT_URI,
     OFFLINE_TO_ONLINE_JOB_TYPE,
     STREAM_TO_ONLINE_JOB_TYPE,
     JobInfo,
     _cancel_job_by_id,
+    _generate_project_hash,
     _generate_project_table_hash,
     _get_api,
     _get_job_by_id,
@@ -340,6 +342,9 @@ class KubernetesJobLauncher(JobLauncher):
                     ingestion_job_params.get_project(),
                     ingestion_job_params.get_feature_table_name(),
                 ),
+                LABEL_PROJECT_HASH: _generate_project_hash(
+                    ingestion_job_params.get_project(),
+                ),
             },
         )
 
@@ -391,6 +396,9 @@ class KubernetesJobLauncher(JobLauncher):
                 LABEL_FEATURE_TABLE_HASH: _generate_project_table_hash(
                     ingestion_job_params.get_project(),
                     ingestion_job_params.get_feature_table_name(),
+                ),
+                LABEL_PROJECT_HASH: _generate_project_hash(
+                    ingestion_job_params.get_project(),
                 ),
             },
         )

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -30,14 +30,13 @@ from .k8s_utils import (
     HISTORICAL_RETRIEVAL_JOB_TYPE,
     LABEL_FEATURE_TABLE,
     LABEL_FEATURE_TABLE_HASH,
-    LABEL_PROJECT_HASH,
+    LABEL_PROJECT,
     METADATA_JOBHASH,
     METADATA_OUTPUT_URI,
     OFFLINE_TO_ONLINE_JOB_TYPE,
     STREAM_TO_ONLINE_JOB_TYPE,
     JobInfo,
     _cancel_job_by_id,
-    _generate_project_hash,
     _generate_project_table_hash,
     _get_api,
     _get_job_by_id,
@@ -342,9 +341,7 @@ class KubernetesJobLauncher(JobLauncher):
                     ingestion_job_params.get_project(),
                     ingestion_job_params.get_feature_table_name(),
                 ),
-                LABEL_PROJECT_HASH: _generate_project_hash(
-                    ingestion_job_params.get_project(),
-                ),
+                LABEL_PROJECT: ingestion_job_params.get_project(),
             },
         )
 
@@ -397,9 +394,7 @@ class KubernetesJobLauncher(JobLauncher):
                     ingestion_job_params.get_project(),
                     ingestion_job_params.get_feature_table_name(),
                 ),
-                LABEL_PROJECT_HASH: _generate_project_hash(
-                    ingestion_job_params.get_project(),
-                ),
+                LABEL_PROJECT: ingestion_job_params.get_project(),
             },
         )
 

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -14,7 +14,6 @@ __all__ = [
     "_prepare_job_resource",
     "_list_jobs",
     "_get_job_by_id",
-    "_generate_project_hash",
     "_generate_project_table_hash",
     "STREAM_TO_ONLINE_JOB_TYPE",
     "OFFLINE_TO_ONLINE_JOB_TYPE",
@@ -32,7 +31,7 @@ LABEL_JOBID = "feast.dev/jobid"
 LABEL_JOBTYPE = "feast.dev/type"
 LABEL_FEATURE_TABLE = "feast.dev/table"
 LABEL_FEATURE_TABLE_HASH = "feast.dev/tablehash"
-LABEL_PROJECT_HASH = "feast.dev/projecthash"
+LABEL_PROJECT = "feast.dev/project"
 
 # Can't store these bits of info in k8s labels due to 64-character limit, so we store them as
 # sparkConf
@@ -103,10 +102,6 @@ def _add_keys(resource: Dict[str, Any], path: Tuple[str, ...], items: Dict[str, 
         if v is not None:
             obj[k] = v
     return resource
-
-
-def _generate_project_hash(project: str) -> str:
-    return hashlib.md5(project.encode()).hexdigest()
 
 
 def _generate_project_table_hash(project: str, table_name: str) -> str:
@@ -251,10 +246,8 @@ def _list_jobs(
             label_selector=f"{LABEL_FEATURE_TABLE_HASH}={table_name_hash}",
         )
     elif project:
-        project_hash = _generate_project_hash(project)
         response = api.list_namespaced_custom_object(
-            **_crd_args(namespace),
-            label_selector=f"{LABEL_PROJECT_HASH}={project_hash}",
+            **_crd_args(namespace), label_selector=f"{LABEL_PROJECT}={project}",
         )
     else:
         # Retrieval jobs

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "_prepare_job_resource",
     "_list_jobs",
     "_get_job_by_id",
+    "_generate_project_hash",
     "_generate_project_table_hash",
     "STREAM_TO_ONLINE_JOB_TYPE",
     "OFFLINE_TO_ONLINE_JOB_TYPE",
@@ -31,6 +32,7 @@ LABEL_JOBID = "feast.dev/jobid"
 LABEL_JOBTYPE = "feast.dev/type"
 LABEL_FEATURE_TABLE = "feast.dev/table"
 LABEL_FEATURE_TABLE_HASH = "feast.dev/tablehash"
+LABEL_PROJECT_HASH = "feast.dev/projecthash"
 
 # Can't store these bits of info in k8s labels due to 64-character limit, so we store them as
 # sparkConf
@@ -101,6 +103,10 @@ def _add_keys(resource: Dict[str, Any], path: Tuple[str, ...], items: Dict[str, 
         if v is not None:
             obj[k] = v
     return resource
+
+
+def _generate_project_hash(project: str) -> str:
+    return hashlib.md5(project.encode()).hexdigest()
 
 
 def _generate_project_table_hash(project: str, table_name: str) -> str:
@@ -243,6 +249,12 @@ def _list_jobs(
         response = api.list_namespaced_custom_object(
             **_crd_args(namespace),
             label_selector=f"{LABEL_FEATURE_TABLE_HASH}={table_name_hash}",
+        )
+    elif project:
+        project_hash = _generate_project_hash(project)
+        response = api.list_namespaced_custom_object(
+            **_crd_args(namespace),
+            label_selector=f"{LABEL_PROJECT_HASH}={project_hash}",
         )
     else:
         # Retrieval jobs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Introduced in this [PR](https://github.com/feast-dev/feast-spark/pull/16), it misses the case where only project is provided as a filter. This is required to list all jobs related to feast project only, without featuretable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
