### PR TITLE
Allow only project filter when listing ft

### DIFF
--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -30,6 +30,7 @@ from .k8s_utils import (
     HISTORICAL_RETRIEVAL_JOB_TYPE,
     LABEL_FEATURE_TABLE,
     LABEL_FEATURE_TABLE_HASH,
+    LABEL_PROJECT,
     METADATA_JOBHASH,
     METADATA_OUTPUT_URI,
     OFFLINE_TO_ONLINE_JOB_TYPE,
@@ -340,6 +341,7 @@ class KubernetesJobLauncher(JobLauncher):
                     ingestion_job_params.get_project(),
                     ingestion_job_params.get_feature_table_name(),
                 ),
+                LABEL_PROJECT: ingestion_job_params.get_project(),
             },
         )
 
@@ -392,6 +394,7 @@ class KubernetesJobLauncher(JobLauncher):
                     ingestion_job_params.get_project(),
                     ingestion_job_params.get_feature_table_name(),
                 ),
+                LABEL_PROJECT: ingestion_job_params.get_project(),
             },
         )
 

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -31,6 +31,7 @@ LABEL_JOBID = "feast.dev/jobid"
 LABEL_JOBTYPE = "feast.dev/type"
 LABEL_FEATURE_TABLE = "feast.dev/table"
 LABEL_FEATURE_TABLE_HASH = "feast.dev/tablehash"
+LABEL_PROJECT = "feast.dev/project"
 
 # Can't store these bits of info in k8s labels due to 64-character limit, so we store them as
 # sparkConf
@@ -243,6 +244,10 @@ def _list_jobs(
         response = api.list_namespaced_custom_object(
             **_crd_args(namespace),
             label_selector=f"{LABEL_FEATURE_TABLE_HASH}={table_name_hash}",
+        )
+    elif project:
+        response = api.list_namespaced_custom_object(
+            **_crd_args(namespace), label_selector=f"{LABEL_PROJECT}={project}",
         )
     else:
         # Retrieval jobs


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Introduced in this [PR](https://github.com/feast-dev/feast-spark/pull/16), it misses the case where only project is provided as a filter. This is required to list all jobs related to feast project only, without featuretable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
