### PR TITLE
Better cleanup for cached rdds in Streaming Ingestion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 
     <properties>
         <revision>0.1.0-SNAPSHOT</revision>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <scala.version>2.12</scala.version>
         <scala.fullVersion>${scala.version}.12</scala.fullVersion>
         <spark.version>3.0.1</spark.version>

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -136,7 +136,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
               })
         }
 
-        rowsAfterValidation.unpersist()
+        sparkSession.sharedState.cacheManager.uncacheQuery(batchDF, cascade = true)
         () // return Unit to avoid compile error with overloaded foreachBatch
       }
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -128,6 +128,7 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
         }
       }
     }
+    dataToStore.unpersist()
   }
 
   private def compactRowsToLatestTimestamp(rows: Seq[(RedisKeyV2, Row)]) = rows


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Long-living streaming ingestion jobs could occupy all memory with cached RDDs. My guess is that `checkpoint` which we call after `repartition` in `RedisSinkRelation` (required to group all rows with the same entity together) is not being properly cleaned up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
