### PR TITLE
Make field mapping for batch source consistent with streaming source

### DIFF
--- a/python/feast_spark/pyspark/historical_feature_retrieval_job.py
+++ b/python/feast_spark/pyspark/historical_feature_retrieval_job.py
@@ -76,7 +76,7 @@ class FileSource(Source):
         created_timestamp_column (str): Column representing the creation timestamp. Required
             only if the source corresponds to a feature table.
         field_mapping (Dict[str, str]): Optional. If present, the source column will be renamed
-            based on the mapping.
+            based on the mapping. The key would be the final result and the value would be the source column.
         options (Optional[Dict[str, str]]): Options to be passed to spark while reading the file source.
     """
 
@@ -124,7 +124,7 @@ class BigQuerySource(Source):
         dataset (str): BQ dataset.
         table (str): BQ table.
         field_mapping (Dict[str, str]): Optional. If present, the source column will be renamed
-            based on the mapping.
+            based on the mapping. The key would be the final result and value would be the source column.
         event_timestamp_column (str): Column representing the event timestamp.
         created_timestamp_column (str): Column representing the creation timestamp. Required
             only if the source corresponds to a feature table.
@@ -279,8 +279,9 @@ class FileDestination(NamedTuple):
 
 
 def _map_column(df: DataFrame, col_mapping: Dict[str, str]):
+    source_to_alias_map = {v: k for k, v in col_mapping.items()}
     projection = [
-        col(col_name).alias(col_mapping.get(col_name, col_name))
+        col(col_name).alias(source_to_alias_map.get(col_name, col_name))
         for col_name in df.columns
     ]
     return df.select(projection)
@@ -667,14 +668,14 @@ def retrieve_historical_features(
                 "format": {"jsonClass": "ParquetFormat"},
                 "path": "file:///some_dir/customer_driver_pairs.csv"),
                 "options": {"inferSchema": "true", "header": "true"},
-                "field_mapping": {"id": "driver_id"}
+                "field_mapping": {"driver_id": "id"}
             }
 
         >>> feature_tables_sources_conf = [
                 {
                     "format": {"json_class": "ParquetFormat"},
                     "path": "gs://some_bucket/bookings.parquet"),
-                    "field_mapping": {"id": "driver_id"}
+                    "field_mapping": {"driver_id": "id"}
                 },
                 {
                     "format": {"json_class": "AvroFormat", schema_json: "..avro schema.."},

--- a/python/tests/test_historical_feature_retrieval.py
+++ b/python/tests/test_historical_feature_retrieval.py
@@ -647,7 +647,7 @@ def test_historical_feature_retrieval_with_mapping(spark: SparkSession):
             "format": {"json_class": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'column_mapping_test_entity.csv')}",
             "event_timestamp_column": "event_timestamp",
-            "field_mapping": {"id": "customer_id"},
+            "field_mapping": {"customer_id": "id"},
             "options": {"inferSchema": "true", "header": "true"},
         }
     }
@@ -717,7 +717,7 @@ def test_large_historical_feature_retrieval(
             "format": {"json_class": "CSVFormat"},
             "path": f"file://{large_entity_csv_file}",
             "event_timestamp_column": "event_timestamp",
-            "field_mapping": {"id": "customer_id"},
+            "field_mapping": {"customer_id": "id"},
             "options": {"inferSchema": "true", "header": "true"},
         }
     }


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@go-jek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
In streaming source, the field mapping represents the mapping from alias to source column name. On the other hand, in batch source, the field mapping represents the mapping from source column name to alias. This PR makes the batch source follows the convention adopted by streaming source.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Breaking change: Field mapping for batch sources now represents the mapping from alias to source column name, so that it is consistent with the streaming source convention.
```
