### PR TITLE
Bigtable as alternative Online Storage

### DIFF
--- a/infra/scripts/test-end-to-end-gcp.sh
+++ b/infra/scripts/test-end-to-end-gcp.sh
@@ -46,6 +46,7 @@ helm_install "js" "${DOCKER_REPOSITORY}" "${GIT_TAG}" "$NAMESPACE" \
   --set "feast-jobservice.envOverrides.FEAST_DATAPROC_REGION=us-central1" \
   --set "feast-jobservice.envOverrides.FEAST_SPARK_STAGING_LOCATION=gs://feast-templocation-kf-feast/" \
   --set "feast-jobservice.envOverrides.FEAST_REDIS_HOST=10.128.0.105" \
+  --set "feast-jobservice.envOverrides.FEAST_REDIS_PORT=6379" \
   --set 'feast-online-serving.application-override\.yaml.feast.stores[0].type=REDIS_CLUSTER' \
   --set 'feast-online-serving.application-override\.yaml.feast.stores[0].name=online' \
   --set 'feast-online-serving.application-override\.yaml.feast.stores[0].config.connection_string=10.128.0.105:6379' \

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <protobuf.version>3.12.2</protobuf.version>
         <commons.lang3.version>3.10</commons.lang3.version>
+        <hbase.version>2.1.10</hbase.version>
 
         <license.content><![CDATA[
 /*

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -100,19 +100,19 @@ class ConfigOptions(metaclass=ConfigMeta):
     HISTORICAL_FEATURE_OUTPUT_LOCATION: Optional[str] = None
 
     #: Default Redis host
-    REDIS_HOST: Optional[str] = "localhost"
+    REDIS_HOST: Optional[str] = ""
 
     #: Default Redis port
-    REDIS_PORT: Optional[str] = "6379"
+    REDIS_PORT: Optional[str] = ""
 
     #: Enable or disable TLS/SSL to Redis
     REDIS_SSL: Optional[str] = "False"
 
     #: BigTable Project ID
-    BIGTABLE_PROJECT: Optional[str] = None
+    BIGTABLE_PROJECT: Optional[str] = ""
 
     #: BigTable Instance ID
-    BIGTABLE_INSTANCE: Optional[str] = None
+    BIGTABLE_INSTANCE: Optional[str] = ""
 
     #: Enable or disable StatsD
     STATSD_ENABLED: str = "False"

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -100,13 +100,19 @@ class ConfigOptions(metaclass=ConfigMeta):
     HISTORICAL_FEATURE_OUTPUT_LOCATION: Optional[str] = None
 
     #: Default Redis host
-    REDIS_HOST: str = "localhost"
+    REDIS_HOST: Optional[str] = "localhost"
 
     #: Default Redis port
-    REDIS_PORT: str = "6379"
+    REDIS_PORT: Optional[str] = "6379"
 
     #: Enable or disable TLS/SSL to Redis
-    REDIS_SSL: str = "False"
+    REDIS_SSL: Optional[str] = "False"
+
+    #: BigTable Project ID
+    BIGTABLE_PROJECT: Optional[str] = None
+
+    #: BigTable Instance ID
+    BIGTABLE_INSTANCE: Optional[str] = None
 
     #: Enable or disable StatsD
     STATSD_ENABLED: str = "False"

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -328,9 +328,11 @@ class IngestionJobParameters(SparkJobParameters):
         feature_table: Dict,
         source: Dict,
         jar: str,
-        redis_host: str,
-        redis_port: int,
-        redis_ssl: bool,
+        redis_host: Optional[str] = None,
+        redis_port: Optional[int] = None,
+        redis_ssl: Optional[bool] = None,
+        bigtable_project: Optional[str] = None,
+        bigtable_instance: Optional[str] = None,
         statsd_host: Optional[str] = None,
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
@@ -343,6 +345,8 @@ class IngestionJobParameters(SparkJobParameters):
         self._redis_host = redis_host
         self._redis_port = redis_port
         self._redis_ssl = redis_ssl
+        self._bigtable_project = bigtable_project
+        self._bigtable_instance = bigtable_instance
         self._statsd_host = statsd_host
         self._statsd_port = statsd_port
         self._deadletter_path = deadletter_path
@@ -351,6 +355,9 @@ class IngestionJobParameters(SparkJobParameters):
 
     def _get_redis_config(self):
         return dict(host=self._redis_host, port=self._redis_port, ssl=self._redis_ssl)
+
+    def _get_bigtable_config(self):
+        return dict(project_id=self._bigtable_project, instance_id=self._bigtable_instance)
 
     def _get_statsd_config(self):
         return (
@@ -377,9 +384,13 @@ class IngestionJobParameters(SparkJobParameters):
             json.dumps(self._feature_table),
             "--source",
             json.dumps(self._source),
-            "--redis",
-            json.dumps(self._get_redis_config()),
         ]
+
+        if self._redis_host and self._redis_host:
+            args.extend(["--redis", json.dumps(self._get_redis_config())])
+
+        if self._bigtable_project and self._bigtable_instance:
+            args.extend(["--bigtable", json.dumps(self._get_bigtable_config())])
 
         if self._get_statsd_config():
             args.extend(["--statsd", json.dumps(self._get_statsd_config())])
@@ -409,9 +420,11 @@ class BatchIngestionJobParameters(IngestionJobParameters):
         start: datetime,
         end: datetime,
         jar: str,
-        redis_host: str,
-        redis_port: int,
-        redis_ssl: bool,
+        redis_host: Optional[str],
+        redis_port: Optional[int],
+        redis_ssl: Optional[bool],
+        bigtable_project: Optional[str],
+        bigtable_instance: Optional[str],
         statsd_host: Optional[str] = None,
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
@@ -424,6 +437,8 @@ class BatchIngestionJobParameters(IngestionJobParameters):
             redis_host,
             redis_port,
             redis_ssl,
+            bigtable_project,
+            bigtable_instance,
             statsd_host,
             statsd_port,
             deadletter_path,
@@ -459,9 +474,11 @@ class StreamIngestionJobParameters(IngestionJobParameters):
         source: Dict,
         jar: str,
         extra_jars: List[str],
-        redis_host: str,
-        redis_port: int,
-        redis_ssl: bool,
+        redis_host: Optional[str],
+        redis_port: Optional[int],
+        redis_ssl: Optional[bool],
+        bigtable_project: Optional[str],
+        bigtable_instance: Optional[str],
         statsd_host: Optional[str] = None,
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
@@ -476,6 +493,8 @@ class StreamIngestionJobParameters(IngestionJobParameters):
             redis_host,
             redis_port,
             redis_ssl,
+            bigtable_project,
+            bigtable_instance,
             statsd_host,
             statsd_port,
             deadletter_path,

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -357,7 +357,9 @@ class IngestionJobParameters(SparkJobParameters):
         return dict(host=self._redis_host, port=self._redis_port, ssl=self._redis_ssl)
 
     def _get_bigtable_config(self):
-        return dict(project_id=self._bigtable_project, instance_id=self._bigtable_instance)
+        return dict(
+            project_id=self._bigtable_project, instance_id=self._bigtable_instance
+        )
 
     def _get_statsd_config(self):
         return (

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -388,7 +388,7 @@ class IngestionJobParameters(SparkJobParameters):
             json.dumps(self._source),
         ]
 
-        if self._redis_host and self._redis_host:
+        if self._redis_host and self._redis_port:
             args.extend(["--redis", json.dumps(self._get_redis_config())])
 
         if self._bigtable_project and self._bigtable_instance:

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -298,7 +298,7 @@ def get_stream_to_online_ingestion_params(
         source=_source_to_argument(feature_table.stream_source, client.config),
         feature_table=_feature_table_to_argument(client, project, feature_table),
         redis_host=client.config.get(opt.REDIS_HOST),
-        redis_port=client.config.getint(opt.REDIS_PORT),
+        redis_port=bool(client.config.get(opt.REDIS_HOST)) and client.config.getint(opt.REDIS_PORT),
         redis_ssl=client.config.getboolean(opt.REDIS_SSL),
         bigtable_project=client.config.get(opt.BIGTABLE_PROJECT),
         bigtable_instance=client.config.get(opt.BIGTABLE_INSTANCE),

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -271,7 +271,8 @@ def start_offline_to_online_ingestion(
             start=start,
             end=end,
             redis_host=client.config.get(opt.REDIS_HOST),
-            redis_port=client.config.getint(opt.REDIS_PORT),
+            redis_port=bool(client.config.get(opt.REDIS_HOST))
+            and client.config.getint(opt.REDIS_PORT),
             redis_ssl=client.config.getboolean(opt.REDIS_SSL),
             bigtable_project=client.config.get(opt.BIGTABLE_PROJECT),
             bigtable_instance=client.config.get(opt.BIGTABLE_INSTANCE),

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -273,6 +273,8 @@ def start_offline_to_online_ingestion(
             redis_host=client.config.get(opt.REDIS_HOST),
             redis_port=client.config.getint(opt.REDIS_PORT),
             redis_ssl=client.config.getboolean(opt.REDIS_SSL),
+            bigtable_project=client.config.get(opt.BIGTABLE_PROJECT),
+            bigtable_instance=client.config.get(opt.BIGTABLE_INSTANCE),
             statsd_host=(
                 client.config.getboolean(opt.STATSD_ENABLED)
                 and client.config.get(opt.STATSD_HOST)
@@ -298,6 +300,8 @@ def get_stream_to_online_ingestion_params(
         redis_host=client.config.get(opt.REDIS_HOST),
         redis_port=client.config.getint(opt.REDIS_PORT),
         redis_ssl=client.config.getboolean(opt.REDIS_SSL),
+        bigtable_project=client.config.get(opt.BIGTABLE_PROJECT),
+        bigtable_instance=client.config.get(opt.BIGTABLE_INSTANCE),
         statsd_host=client.config.getboolean(opt.STATSD_ENABLED)
         and client.config.get(opt.STATSD_HOST),
         statsd_port=client.config.getboolean(opt.STATSD_ENABLED)

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -298,7 +298,8 @@ def get_stream_to_online_ingestion_params(
         source=_source_to_argument(feature_table.stream_source, client.config),
         feature_table=_feature_table_to_argument(client, project, feature_table),
         redis_host=client.config.get(opt.REDIS_HOST),
-        redis_port=bool(client.config.get(opt.REDIS_HOST)) and client.config.getint(opt.REDIS_PORT),
+        redis_port=bool(client.config.get(opt.REDIS_HOST))
+        and client.config.getint(opt.REDIS_PORT),
         redis_ssl=client.config.getboolean(opt.REDIS_SSL),
         bigtable_project=client.config.get(opt.BIGTABLE_PROJECT),
         bigtable_instance=client.config.get(opt.BIGTABLE_INSTANCE),

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -287,6 +287,7 @@ class KubernetesJobLauncher(JobLauncher):
             jar_path.startswith("s3://")
             or jar_path.startswith("s3a://")
             or jar_path.startswith("https://")
+            or jar_path.startswith("local://")
         ):
             return jar_path
         elif jar_path.startswith("file://"):

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -99,6 +99,30 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hbase.connectors.spark</groupId>
+            <artifactId>hbase-spark</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigtable</groupId>
+            <artifactId>bigtable-hbase-2.x-hadoop</artifactId>
+            <version>1.19.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>1.3.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>1.3.6</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
             <version>3.0.16</version>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -99,27 +99,33 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hbase.connectors.spark</groupId>
-            <artifactId>hbase-spark</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-2.x-hadoop</artifactId>
             <version>1.19.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-server</artifactId>
-            <version>1.3.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>1.3.6</version>
+            <version>${hbase.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-mapreduce</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -38,6 +38,10 @@ object BasePipeline {
           .set("spark.redis.host", host)
           .set("spark.redis.port", port.toString)
           .set("spark.redis.ssl", ssl.toString)
+      case BigTableConfig(projectId, instanceId) =>
+        conf
+          .set("spark.bigtable.projectId", projectId)
+          .set("spark.bigtable.instanceId", instanceId)
     }
 
     jobConfig.metrics match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -77,7 +77,10 @@ object BatchPipeline extends BasePipeline {
       .filter(rowValidator.allChecks)
 
     validRows.write
-      .format("feast.ingestion.stores.redis")
+      .format(config.store match {
+        case _:RedisConfig => "feast.ingestion.stores.redis"
+        case _:BigTableConfig => "feast.ingestion.stored.bigtable"
+      })
       .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
       .option("namespace", featureTable.name)
       .option("project_name", featureTable.project)

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -78,8 +78,8 @@ object BatchPipeline extends BasePipeline {
 
     validRows.write
       .format(config.store match {
-        case _:RedisConfig => "feast.ingestion.stores.redis"
-        case _:BigTableConfig => "feast.ingestion.stored.bigtable"
+        case _: RedisConfig    => "feast.ingestion.stores.redis"
+        case _: BigTableConfig => "feast.ingestion.stores.bigtable"
       })
       .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
       .option("namespace", featureTable.name)

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -81,6 +81,9 @@ object IngestionJob {
     opt[String](name = "redis")
       .action((x, c) => c.copy(store = parseJSON(x).extract[RedisConfig]))
 
+    opt[String](name = "bigtable")
+      .action((x, c) => c.copy(store = parseJSON(x).camelizeKeys.extract[BigTableConfig]))
+
     opt[String](name = "statsd")
       .action((x, c) => c.copy(metrics = Some(parseJSON(x).extract[StatsDConfig])))
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -26,8 +26,8 @@ object Modes extends Enumeration {
 
 abstract class StoreConfig
 
-case class RedisConfig(host: String, port: Int, ssl: Boolean) extends StoreConfig
-case class BigTableConfig(projectId: String, intanceId: String) extends StoreConfig
+case class RedisConfig(host: String, port: Int, ssl: Boolean)    extends StoreConfig
+case class BigTableConfig(projectId: String, instanceId: String) extends StoreConfig
 
 sealed trait MetricConfig
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -27,6 +27,7 @@ object Modes extends Enumeration {
 abstract class StoreConfig
 
 case class RedisConfig(host: String, port: Int, ssl: Boolean) extends StoreConfig
+case class BigTableConfig(projectId: String, intanceId: String) extends StoreConfig
 
 sealed trait MetricConfig
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -120,8 +120,9 @@ class BigTableSinkRelation(
     val key              = schemaKeyPrefix.getBytes ++ serializer.schemaReference(featureSchema)
     val serializedSchema = serializer.serializeSchema(featureSchema).getBytes
 
-    val put = new Put(key)
-    put.addColumn(metadataColumnFamily.getBytes, emptyQualifier.getBytes, serializedSchema)
+    val put       = new Put(key)
+    val qualifier = "avro".getBytes
+    put.addColumn(metadataColumnFamily.getBytes, qualifier, serializedSchema)
 
     val btConn = BigtableConfiguration.connect(hadoopConfig)
     try {
@@ -129,7 +130,7 @@ class BigTableSinkRelation(
       table.checkAndPut(
         key,
         metadataColumnFamily.getBytes,
-        "avro".getBytes,
+        qualifier,
         null,
         put
       )

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -1,0 +1,128 @@
+package feast.ingestion.stores.bigtable
+
+import com.google.cloud.bigtable.hbase.BigtableConfiguration
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName}
+import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable
+import org.apache.hadoop.hbase.mapred.TableOutputFormat
+import org.apache.hadoop.mapred.JobConf
+import org.apache.spark.sql.avro.SchemaConverters
+import org.apache.spark.sql.avro.functions.to_avro
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.{col, struct, udf}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
+import org.apache.spark.sql.types.StructType
+
+import com.google.common.hash.Hashing
+
+class BigTableSinkRelation(override val sqlContext: SQLContext,
+                           val config: SparkBigtableConfig,
+                           val hadoopConfig: Configuration)
+  extends BaseRelation with InsertableRelation with Serializable {
+
+  override def schema: StructType = ???
+
+  def createTable(): Unit = {
+    val btConn = BigtableConfiguration.connect(hadoopConfig)
+    val admin = btConn.getAdmin
+    if (!admin.isTableAvailable(TableName.valueOf(tableName))) {
+      val tableDesc = new HTableDescriptor(TableName.valueOf(tableName))
+
+      val featuresCF = new HColumnDescriptor(featureColumnFamily)
+      featuresCF.setTimeToLive(config.maxAge.toInt)
+      featuresCF.setVersions(0, 1)
+      tableDesc.addFamily(featuresCF)
+
+      val metadataCF = new HColumnDescriptor(metadataColumnFamily)
+      tableDesc.addFamily(metadataCF)
+
+      admin.createTable(tableDesc)
+    }
+  }
+
+  override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+    val jobConfig: JobConf = new JobConf(hadoopConfig, this.getClass)
+    jobConfig.setOutputFormat(classOf[TableOutputFormat])
+    jobConfig.set(TableOutputFormat.OUTPUT_TABLE, tableName)
+
+    val featureColumns = data.schema.fields.map(_.name).filterNot(
+      isSystemColumn
+    ).map(col)
+
+    val entityColumns = config.entityColumns.map(col)
+    val schemaReference = writeSchemaReference(data.schema)
+
+    data
+      .select(
+        convertToPut(schemaReference)(
+          joinEntityKey(struct(entityColumns:_*)),
+          to_avro(struct(featureColumns:_*)),
+          col(config.timestampColumn)
+        )
+      ).rdd
+      .map{ r: Row => (r.get(0), r.get(1))}
+      .saveAsHadoopDataset(jobConfig)
+
+  }
+
+  private def writeSchema(schema: StructType): String = {
+    val avroSchema = SchemaConverters.toAvroType(
+      StructType(
+        // excluding entities & timestamp, so the schema would match to what we actually write as value
+        schema.fields.filterNot(f => isSystemColumn(f.name))
+      )
+    )
+    avroSchema.toString
+  }
+
+  private def writeSchemaReference(schema: StructType): Array[Byte] = {
+    Hashing.murmur3_32().hashBytes(writeSchema(schema).getBytes).asBytes()
+  }
+
+  def saveWriteSchema(data: DataFrame): Unit = {
+    val btConn = BigtableConfiguration.connect(hadoopConfig)
+    val table = btConn.getTable(TableName.valueOf(tableName))
+    val key = s"schema#".getBytes ++ writeSchemaReference(data.schema)
+
+    val put = new Put(key)
+    put.addColumn(metadataColumnFamily.getBytes, "json".getBytes, writeSchema(data.schema).getBytes)
+
+    table.checkAndPut(
+      key,
+      metadataColumnFamily.getBytes,
+      "json".getBytes,
+      null,
+      put
+    )
+
+  }
+
+
+  private def tableName: String = {
+    val entities = config.entityColumns.mkString("_")
+    s"${config.projectName}_${entities}"
+  }
+
+  private def joinEntityKey: UserDefinedFunction = udf {
+    r: Row => ((0 until r.size)).map(r.getString).mkString("#")
+  }
+
+  private def convertToPut(schemaReference: Array[Byte]): UserDefinedFunction = udf {
+    (key: Array[Byte], value: Array[Byte], ts: java.sql.Timestamp) =>
+      val put = new Put(key, ts.getTime)
+      put.addColumn(
+        featureColumnFamily.getBytes,
+        config.namespace.getBytes,
+        schemaReference ++ value
+      )
+      (new ImmutableBytesWritable, put)
+  }
+
+  private val featureColumnFamily = "features"
+  private val metadataColumnFamily = "metadata"
+
+  private def isSystemColumn(name: String) =
+    (config.entityColumns ++ Seq(config.timestampColumn)).contains(name)
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/DefaultSource.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/DefaultSource.scala
@@ -1,25 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feast.ingestion.stores.bigtable
 
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider}
 import com.google.cloud.bigtable.hbase.BigtableConfiguration
+import feast.ingestion.stores.bigtable.serialization.AvroSerializer
 
-class DefaultSource extends CreatableRelationProvider{
-  override def createRelation(sqlContext: SQLContext,
-                              mode: SaveMode,
-                              parameters: Map[String, String],
-                              data: DataFrame): BaseRelation = {
+class DefaultSource extends CreatableRelationProvider {
+  override def createRelation(
+      sqlContext: SQLContext,
+      mode: SaveMode,
+      parameters: Map[String, String],
+      data: DataFrame
+  ): BaseRelation = {
     val bigtableConf = BigtableConfiguration.configure(
       sqlContext.getConf("spark.bigtable.projectId"),
-      sqlContext.getConf("spark.bigtable.instanceId"))
+      sqlContext.getConf("spark.bigtable.instanceId")
+    )
 
     if (sqlContext.getConf("spark.bigtable.emulatorHost", "").nonEmpty) {
       bigtableConf.set(
         "google.bigtable.emulator.endpoint.host",
-        sqlContext.getConf("spark.bigtable.emulatorHost"))
+        sqlContext.getConf("spark.bigtable.emulatorHost")
+      )
     }
 
-    val rel = new BigTableSinkRelation(sqlContext, SparkBigtableConfig.parse(parameters), bigtableConf)
+    val rel =
+      new BigTableSinkRelation(sqlContext, new AvroSerializer, SparkBigtableConfig.parse(parameters), bigtableConf)
     rel.createTable()
     rel.saveWriteSchema(data)
     rel.insert(data, overwrite = false)

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/DefaultSource.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/DefaultSource.scala
@@ -1,0 +1,28 @@
+package feast.ingestion.stores.bigtable
+
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider}
+import com.google.cloud.bigtable.hbase.BigtableConfiguration
+
+class DefaultSource extends CreatableRelationProvider{
+  override def createRelation(sqlContext: SQLContext,
+                              mode: SaveMode,
+                              parameters: Map[String, String],
+                              data: DataFrame): BaseRelation = {
+    val bigtableConf = BigtableConfiguration.configure(
+      sqlContext.getConf("spark.bigtable.projectId"),
+      sqlContext.getConf("spark.bigtable.instanceId"))
+
+    if (sqlContext.getConf("spark.bigtable.emulatorHost", "").nonEmpty) {
+      bigtableConf.set(
+        "google.bigtable.emulator.endpoint.host",
+        sqlContext.getConf("spark.bigtable.emulatorHost"))
+    }
+
+    val rel = new BigTableSinkRelation(sqlContext, SparkBigtableConfig.parse(parameters), bigtableConf)
+    rel.createTable()
+    rel.saveWriteSchema(data)
+    rel.insert(data, overwrite = false)
+    rel
+  }
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/DefaultSource.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/DefaultSource.scala
@@ -41,7 +41,12 @@ class DefaultSource extends CreatableRelationProvider {
     }
 
     val rel =
-      new BigTableSinkRelation(sqlContext, new AvroSerializer, SparkBigtableConfig.parse(parameters), bigtableConf)
+      new BigTableSinkRelation(
+        sqlContext,
+        new AvroSerializer,
+        SparkBigtableConfig.parse(parameters),
+        bigtableConf
+      )
     rel.createTable()
     rel.saveWriteSchema(data)
     rel.insert(data, overwrite = false)

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/SparkBigtableConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/SparkBigtableConfig.scala
@@ -1,19 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feast.ingestion.stores.bigtable
 
-
-case class SparkBigtableConfig (
-  namespace: String,
-                                 projectName: String,
-                                 entityColumns: Array[String],
-                                 timestampColumn: String,
-  maxAge: Long,
-                               )
+case class SparkBigtableConfig(
+    namespace: String,
+    projectName: String,
+    entityColumns: Array[String],
+    timestampColumn: String,
+    maxAge: Long
+)
 object SparkBigtableConfig {
-  val NAMESPACE = "namespace"
+  val NAMESPACE      = "namespace"
   val ENTITY_COLUMNS = "entity_columns"
-  val TS_COLUMN = "timestamp_column"
-  val PROJECT_NAME = "project_name"
-  val MAX_AGE = "max_age"
+  val TS_COLUMN      = "timestamp_column"
+  val PROJECT_NAME   = "project_name"
+  val MAX_AGE        = "max_age"
 
   def parse(parameters: Map[String, String]): SparkBigtableConfig =
     SparkBigtableConfig(

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/SparkBigtableConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/SparkBigtableConfig.scala
@@ -1,0 +1,26 @@
+package feast.ingestion.stores.bigtable
+
+
+case class SparkBigtableConfig (
+  namespace: String,
+                                 projectName: String,
+                                 entityColumns: Array[String],
+                                 timestampColumn: String,
+  maxAge: Long,
+                               )
+object SparkBigtableConfig {
+  val NAMESPACE = "namespace"
+  val ENTITY_COLUMNS = "entity_columns"
+  val TS_COLUMN = "timestamp_column"
+  val PROJECT_NAME = "project_name"
+  val MAX_AGE = "max_age"
+
+  def parse(parameters: Map[String, String]): SparkBigtableConfig =
+    SparkBigtableConfig(
+      namespace = parameters.getOrElse(NAMESPACE, ""),
+      projectName = parameters.getOrElse(PROJECT_NAME, "default"),
+      entityColumns = parameters.getOrElse(ENTITY_COLUMNS, "").split(","),
+      timestampColumn = parameters.getOrElse(TS_COLUMN, "event_timestamp"),
+      maxAge = parameters.get(MAX_AGE).map(_.toLong).getOrElse(0)
+    )
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/AvroSerializer.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/AvroSerializer.scala
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.stores.bigtable.serialization
+
+import com.google.common.hash.Hashing
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.avro.SchemaConverters
+import org.apache.spark.sql.avro.functions.to_avro
+import org.apache.spark.sql.types.StructType
+
+class AvroSerializer extends Serializer {
+  def serializeSchema(schema: StructType): String = {
+    val avroSchema = SchemaConverters.toAvroType(schema)
+    avroSchema.toString
+  }
+
+  def schemaReference(schema: StructType): Array[Byte] = {
+    Hashing.murmur3_32().hashBytes(serializeSchema(schema).getBytes).asBytes()
+  }
+
+  def serializeData: Column => Column = to_avro
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/Serializer.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/Serializer.scala
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.stores.bigtable.serialization
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.types.StructType
+
+trait Serializer {
+  def serializeSchema(schema: StructType): String
+
+  def schemaReference(schema: StructType): Array[Byte]
+
+  def serializeData: Column => Column
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -37,8 +37,6 @@ import feast.proto.types.ValueProto
 import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-
-
 class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
 
   override val container = GenericContainer("redis:6.0.8", exposedPorts = Seq(6379))

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -30,18 +30,14 @@ import org.scalatest._
 import redis.clients.jedis.Jedis
 import feast.ingestion.helpers.RedisStorageHelper._
 import feast.ingestion.helpers.DataHelper._
+import feast.ingestion.helpers.TestRow
 import feast.ingestion.metrics.StatsDStub
 import feast.proto.storage.RedisProto.RedisKeyV2
 import feast.proto.types.ValueProto
 import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-case class TestRow(
-    customer: String,
-    feature1: Int,
-    feature2: Float,
-    eventTimestamp: java.sql.Timestamp
-)
+
 
 class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
 
@@ -60,21 +56,6 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
     statsDStub.receivedMetrics // clean the buffer
 
     implicit def testRowEncoder: Encoder[TestRow] = ExpressionEncoder()
-
-    def rowGenerator(start: DateTime, end: DateTime, customerGen: Option[Gen[String]] = None) =
-      for {
-        customer <- customerGen.getOrElse(Gen.asciiPrintableStr)
-        feature1 <- Gen.choose(0, 100)
-        feature2 <- Gen.choose[Float](0, 1)
-        eventTimestamp <- Gen
-          .choose(0, Seconds.secondsBetween(start, end).getSeconds - 1)
-          .map(start.withMillisOfSecond(0).plusSeconds)
-      } yield TestRow(
-        customer,
-        feature1,
-        feature2,
-        new java.sql.Timestamp(eventTimestamp.getMillis)
-      )
 
     def encodeEntityKey(row: TestRow, featureTable: FeatureTable): Array[Byte] = {
       RedisKeyV2

--- a/spark/ingestion/src/test/scala/feast/ingestion/BigTableIngestionSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BigTableIngestionSpec.scala
@@ -1,23 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feast.ingestion
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import com.google.cloud.bigtable.hbase.BigtableConfiguration
 import feast.ingestion.helpers.DataHelper.{generateDistinctRows, rowGenerator, storeAsParquet}
 import feast.ingestion.helpers.TestRow
 import feast.proto.types.ValueProto.ValueType
+import org.apache.avro.Schema
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+import org.apache.avro.io.DecoderFactory
+import org.apache.hadoop.hbase.TableName
+import org.apache.hadoop.hbase.client.{Connection, Scan}
 import org.apache.spark.SparkConf
 import org.joda.time.DateTime
 
-class BigTableIngestionSpec extends SparkSpec with ForAllTestContainer{
+import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
+
+class BigTableIngestionSpec extends SparkSpec with ForAllTestContainer {
   override val container = GenericContainer(
     "google/cloud-sdk:latest",
     exposedPorts = Seq(8086),
-    command = Seq("gcloud beta emulators bigtable start --host-port=0.0.0.0:8086")
+    command = Seq("gcloud", "beta", "emulators", "bigtable", "start", "--host-port", "0.0.0.0:8086")
   )
 
   override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
     .set("spark.bigtable.projectId", "null")
     .set("spark.bigtable.instanceId", "null")
     .set("spark.bigtable.emulatorHost", s"localhost:${container.mappedPort(8086)}")
+
+  def withBTConnection(testCode: Connection => Any): Unit = {
+    val btConf = BigtableConfiguration.configure("null", "null")
+    btConf.set("google.bigtable.emulator.endpoint.host", s"localhost:${container.mappedPort(8086)}")
+    val btConn = BigtableConfiguration.connect(btConf)
+
+    try {
+      testCode(btConn)
+    } finally {
+      btConn.close()
+    }
+  }
 
   trait Scope {
     val config = IngestionJobConfig(
@@ -35,17 +71,76 @@ class BigTableIngestionSpec extends SparkSpec with ForAllTestContainer{
       store = BigTableConfig("", "")
     )
 
+    val gen = rowGenerator(DateTime.parse("2020-08-01"), DateTime.parse("2020-09-01"))
+
+    def decodeAvroValue(value: Array[Byte], jsonFormatSchema: String): GenericRecord = {
+      val input = value.drop(4) // drop schema reference
+
+      val schema      = new Schema.Parser().parse(jsonFormatSchema)
+      val reader      = new GenericDatumReader[Any](schema)
+      var result: Any = null
+
+      val decoder = DecoderFactory.get().binaryDecoder(input, 0, input.length, null)
+      result = reader.read(result, decoder)
+      result.asInstanceOf[GenericRecord]
+    }
+
   }
 
-  "Dataset" should "be ingested in BigTable" in new Scope {
-    val gen      = rowGenerator(DateTime.parse("2020-08-01"), DateTime.parse("2020-09-01"))
-    val rows     = generateDistinctRows(gen, 10000, (_:TestRow).customer)
-    val tempPath = storeAsParquet(sparkSession, rows)
-    val configWithOfflineSource = config.copy(
-      source = FileSource(tempPath, Map.empty, "eventTimestamp")
-    )
+  "Dataset" should "be ingested in BigTable" in withBTConnection { btConn =>
+    new Scope {
+      val rows     = generateDistinctRows(gen, 10000, (_: TestRow).customer)
+      val tempPath = storeAsParquet(sparkSession, rows)
+      val configWithOfflineSource = config.copy(
+        source = FileSource(tempPath, Map.empty, "eventTimestamp")
+      )
 
-    BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
+      BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
 
+      val table       = btConn.getTable(TableName.valueOf("default_customer"))
+      val allRowsInBT = table.getScanner(new Scan).asScala.toList
+
+      val schema = allRowsInBT
+        .filter(_.getRow.startsWith("schema".getBytes))
+        .map(r => new String(r.value))
+        .head
+
+      val storedRows = allRowsInBT
+        .filterNot(_.getRow.startsWith("schema".getBytes))
+        .map(r => {
+          val cell   = r.getColumnLatestCell("test-fs".getBytes, "".getBytes)
+          val record = decodeAvroValue(cell.getValueArray, schema)
+          TestRow(
+            new String(r.getRow),
+            record.get("feature1").asInstanceOf[Integer],
+            record.get("feature2").asInstanceOf[Float],
+            new java.sql.Timestamp(cell.getTimestamp)
+          )
+        })
+
+      storedRows should contain allElementsOf rows.filterNot(_.customer.isEmpty)
+    }
+  }
+
+  "Column family" should "be created with appropriate ttl" in withBTConnection { btConn =>
+    new Scope {
+      val rows     = generateDistinctRows(gen, 1, (_: TestRow).customer)
+      val tempPath = storeAsParquet(sparkSession, rows)
+      val configWithOfflineSource = config.copy(
+        source = FileSource(tempPath, Map.empty, "eventTimestamp"),
+        featureTable = config.featureTable.copy(
+          name = "feature-table-name",
+          maxAge = Some(600L)
+        )
+      )
+
+      BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
+
+      val table = btConn.getAdmin.getDescriptor(TableName.valueOf("default_customer"))
+      val cf    = table.getColumnFamily(configWithOfflineSource.featureTable.name.getBytes)
+      cf.getTimeToLive should be(600)
+      cf.getMaxVersions should be(1)
+      cf.getMinVersions should be(0)
+    }
   }
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/BigTableIngestionSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BigTableIngestionSpec.scala
@@ -97,7 +97,7 @@ class BigTableIngestionSpec extends SparkSpec with ForAllTestContainer {
 
       BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
 
-      val table       = btConn.getTable(TableName.valueOf("default_customer"))
+      val table       = btConn.getTable(TableName.valueOf("default__customer"))
       val allRowsInBT = table.getScanner(new Scan).asScala.toList
 
       val schema = allRowsInBT
@@ -136,7 +136,7 @@ class BigTableIngestionSpec extends SparkSpec with ForAllTestContainer {
 
       BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
 
-      val table = btConn.getAdmin.getDescriptor(TableName.valueOf("default_customer"))
+      val table = btConn.getAdmin.getDescriptor(TableName.valueOf("default__customer"))
       val cf    = table.getColumnFamily(configWithOfflineSource.featureTable.name.getBytes)
       cf.getTimeToLive should be(600)
       cf.getMaxVersions should be(1)

--- a/spark/ingestion/src/test/scala/feast/ingestion/BigTableIngestionSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BigTableIngestionSpec.scala
@@ -1,0 +1,51 @@
+package feast.ingestion
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import feast.ingestion.helpers.DataHelper.{generateDistinctRows, rowGenerator, storeAsParquet}
+import feast.ingestion.helpers.TestRow
+import feast.proto.types.ValueProto.ValueType
+import org.apache.spark.SparkConf
+import org.joda.time.DateTime
+
+class BigTableIngestionSpec extends SparkSpec with ForAllTestContainer{
+  override val container = GenericContainer(
+    "google/cloud-sdk:latest",
+    exposedPorts = Seq(8086),
+    command = Seq("gcloud beta emulators bigtable start --host-port=0.0.0.0:8086")
+  )
+
+  override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
+    .set("spark.bigtable.projectId", "null")
+    .set("spark.bigtable.instanceId", "null")
+    .set("spark.bigtable.emulatorHost", s"localhost:${container.mappedPort(8086)}")
+
+  trait Scope {
+    val config = IngestionJobConfig(
+      featureTable = FeatureTable(
+        name = "test-fs",
+        project = "default",
+        entities = Seq(Field("customer", ValueType.Enum.STRING)),
+        features = Seq(
+          Field("feature1", ValueType.Enum.INT32),
+          Field("feature2", ValueType.Enum.FLOAT)
+        )
+      ),
+      startTime = DateTime.parse("2020-08-01"),
+      endTime = DateTime.parse("2020-09-01"),
+      store = BigTableConfig("", "")
+    )
+
+  }
+
+  "Dataset" should "be ingested in BigTable" in new Scope {
+    val gen      = rowGenerator(DateTime.parse("2020-08-01"), DateTime.parse("2020-09-01"))
+    val rows     = generateDistinctRows(gen, 10000, (_:TestRow).customer)
+    val tempPath = storeAsParquet(sparkSession, rows)
+    val configWithOfflineSource = config.copy(
+      source = FileSource(tempPath, Map.empty, "eventTimestamp")
+    )
+
+    BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
+
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -19,12 +19,7 @@ package feast.ingestion
 import java.nio.file.Paths
 import java.util.Properties
 
-import com.dimafeng.testcontainers.{
-  ForAllTestContainer,
-  GenericContainer,
-  KafkaContainer,
-  MultipleContainers
-}
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer, KafkaContainer, MultipleContainers}
 import feast.proto.types.ValueProto.ValueType
 import org.apache.spark.SparkConf
 import org.joda.time.DateTime
@@ -38,6 +33,7 @@ import redis.clients.jedis.Jedis
 import collection.JavaConverters._
 import feast.ingestion.helpers.RedisStorageHelper._
 import feast.ingestion.helpers.DataHelper._
+import feast.ingestion.helpers.TestRow
 import feast.proto.storage.RedisProto.RedisKeyV2
 import feast.proto.types.ValueProto
 import org.apache.spark.sql.Encoder
@@ -45,14 +41,8 @@ import org.apache.spark.sql.avro.to_avro
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.functions.{col, struct}
 
-class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
-  case class TestRow(
-      customer: String,
-      feature1: Int,
-      feature2: Float,
-      eventTimestamp: java.sql.Timestamp
-  )
 
+class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
   val redisContainer = GenericContainer("redis:6.0.8", exposedPorts = Seq(6379))
   val kafkaContainer = KafkaContainer()
 

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -19,7 +19,12 @@ package feast.ingestion
 import java.nio.file.Paths
 import java.util.Properties
 
-import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer, KafkaContainer, MultipleContainers}
+import com.dimafeng.testcontainers.{
+  ForAllTestContainer,
+  GenericContainer,
+  KafkaContainer,
+  MultipleContainers
+}
 import feast.proto.types.ValueProto.ValueType
 import org.apache.spark.SparkConf
 import org.joda.time.DateTime
@@ -40,7 +45,6 @@ import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.avro.to_avro
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.functions.{col, struct}
-
 
 class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
   val redisContainer = GenericContainer("redis:6.0.8", exposedPorts = Seq(6379))

--- a/spark/ingestion/src/test/scala/feast/ingestion/helpers/DataHelper.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/helpers/DataHelper.scala
@@ -26,11 +26,11 @@ import org.scalacheck.Gen
 import scala.reflect.runtime.universe.TypeTag
 
 case class TestRow(
-                    customer: String,
-                    feature1: Int,
-                    feature2: Float,
-                    eventTimestamp: java.sql.Timestamp
-                  )
+    customer: String,
+    feature1: Int,
+    feature2: Float,
+    eventTimestamp: java.sql.Timestamp
+)
 
 object DataHelper {
   def generateRows[A](gen: Gen[A], N: Int): Seq[A] =
@@ -57,7 +57,11 @@ object DataHelper {
     tempPath
   }
 
-  def rowGenerator(start: DateTime, end: DateTime, customerGen: Option[Gen[String]] = None): Gen[TestRow] =
+  def rowGenerator(
+      start: DateTime,
+      end: DateTime,
+      customerGen: Option[Gen[String]] = None
+  ): Gen[TestRow] =
     for {
       customer <- customerGen.getOrElse(Gen.asciiPrintableStr)
       feature1 <- Gen.choose(0, 100)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Adding BigTable as sink option for ingestion job. Storage could be selected now via JobService options.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #48 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New options were added to JobService configuration
BIGTABLE_PROJECT
BIGTABLE_INSTANCE
```
