### PR TITLE
Add documentation building for readthedocs.org

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+version: 2
+
+sphinx:
+   configuration: python/docs/source/conf.py
+
+formats:
+   - pdf
+
+python:
+  version: 3.7
+  install:
+      - requirements: python/requirements-ci.txt
+      - path: sdk/python/
+        method: setuptools

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ format-python:
 install-python-ci-dependencies:
 	pip install --no-cache-dir -r python/requirements-ci.txt
 
-compile-protos-python: install-python-ci-dependencies
+compile-protos-python:
+	$(MAKE) install-python-ci-dependencies || true
 	@$(eval FEAST_PATH=`python -c "import feast; import os; print(os.path.dirname(feast.__file__))"`)
 	@$(foreach dir,$(PROTO_TYPE_SUBDIRS),cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. -I$(FEAST_PATH)/protos/ --python_out=../python/ --mypy_out=../python/ feast_spark/$(dir)/*.proto;)
 	@$(foreach dir,$(PROTO_SERVICE_SUBDIRS),cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. -I$(FEAST_PATH)/protos/ --grpc_python_out=../python/ feast_spark/$(dir)/*.proto;)

--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -1,0 +1,62 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../feast_spark"))
+sys.path.insert(0, os.path.abspath("../.."))
+
+# -- Project information -----------------------------------------------------
+
+project = 'Feast Spark SDK'
+copyright = '2021, Feast Authors'
+author = 'Feast Authors'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx_rtd_theme",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/python/docs/source/feast_spark.api.rst
+++ b/python/docs/source/feast_spark.api.rst
@@ -1,0 +1,29 @@
+feast\_spark.api package
+========================
+
+Submodules
+----------
+
+feast\_spark.api.JobService\_pb2 module
+---------------------------------------
+
+.. automodule:: feast_spark.api.JobService_pb2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.api.JobService\_pb2\_grpc module
+---------------------------------------------
+
+.. automodule:: feast_spark.api.JobService_pb2_grpc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.api
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.contrib.rst
+++ b/python/docs/source/feast_spark.contrib.rst
@@ -1,0 +1,18 @@
+feast\_spark.contrib package
+============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.contrib.validation
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.contrib
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.contrib.validation.rst
+++ b/python/docs/source/feast_spark.contrib.validation.rst
@@ -1,0 +1,29 @@
+feast\_spark.contrib.validation package
+=======================================
+
+Submodules
+----------
+
+feast\_spark.contrib.validation.base module
+-------------------------------------------
+
+.. automodule:: feast_spark.contrib.validation.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.contrib.validation.ge module
+-----------------------------------------
+
+.. automodule:: feast_spark.contrib.validation.ge
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.contrib.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.pyspark.launchers.aws.rst
+++ b/python/docs/source/feast_spark.pyspark.launchers.aws.rst
@@ -1,0 +1,29 @@
+feast\_spark.pyspark.launchers.aws package
+==========================================
+
+Submodules
+----------
+
+feast\_spark.pyspark.launchers.aws.emr module
+---------------------------------------------
+
+.. automodule:: feast_spark.pyspark.launchers.aws.emr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.pyspark.launchers.aws.emr\_utils module
+----------------------------------------------------
+
+.. automodule:: feast_spark.pyspark.launchers.aws.emr_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.pyspark.launchers.aws
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.pyspark.launchers.gcloud.rst
+++ b/python/docs/source/feast_spark.pyspark.launchers.gcloud.rst
@@ -1,0 +1,21 @@
+feast\_spark.pyspark.launchers.gcloud package
+=============================================
+
+Submodules
+----------
+
+feast\_spark.pyspark.launchers.gcloud.dataproc module
+-----------------------------------------------------
+
+.. automodule:: feast_spark.pyspark.launchers.gcloud.dataproc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.pyspark.launchers.gcloud
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.pyspark.launchers.k8s.rst
+++ b/python/docs/source/feast_spark.pyspark.launchers.k8s.rst
@@ -1,0 +1,29 @@
+feast\_spark.pyspark.launchers.k8s package
+==========================================
+
+Submodules
+----------
+
+feast\_spark.pyspark.launchers.k8s.k8s module
+---------------------------------------------
+
+.. automodule:: feast_spark.pyspark.launchers.k8s.k8s
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.pyspark.launchers.k8s.k8s\_utils module
+----------------------------------------------------
+
+.. automodule:: feast_spark.pyspark.launchers.k8s.k8s_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.pyspark.launchers.k8s
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.pyspark.launchers.rst
+++ b/python/docs/source/feast_spark.pyspark.launchers.rst
@@ -1,0 +1,21 @@
+feast\_spark.pyspark.launchers package
+======================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.pyspark.launchers.aws
+   feast_spark.pyspark.launchers.gcloud
+   feast_spark.pyspark.launchers.k8s
+   feast_spark.pyspark.launchers.standalone
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.pyspark.launchers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.pyspark.launchers.standalone.rst
+++ b/python/docs/source/feast_spark.pyspark.launchers.standalone.rst
@@ -1,0 +1,21 @@
+feast\_spark.pyspark.launchers.standalone package
+=================================================
+
+Submodules
+----------
+
+feast\_spark.pyspark.launchers.standalone.local module
+------------------------------------------------------
+
+.. automodule:: feast_spark.pyspark.launchers.standalone.local
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.pyspark.launchers.standalone
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.pyspark.rst
+++ b/python/docs/source/feast_spark.pyspark.rst
@@ -1,0 +1,45 @@
+feast\_spark.pyspark package
+============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.pyspark.launchers
+
+Submodules
+----------
+
+feast\_spark.pyspark.abc module
+-------------------------------
+
+.. automodule:: feast_spark.pyspark.abc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.pyspark.historical\_feature\_retrieval\_job module
+---------------------------------------------------------------
+
+.. automodule:: feast_spark.pyspark.historical_feature_retrieval_job
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.pyspark.launcher module
+------------------------------------
+
+.. automodule:: feast_spark.pyspark.launcher
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.pyspark
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.rst
+++ b/python/docs/source/feast_spark.rst
@@ -1,0 +1,64 @@
+feast\_spark package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.api
+   feast_spark.contrib
+   feast_spark.pyspark
+   feast_spark.third_party
+
+Submodules
+----------
+
+feast\_spark.cli module
+-----------------------
+
+.. automodule:: feast_spark.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.client module
+--------------------------
+
+.. automodule:: feast_spark.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.constants module
+-----------------------------
+
+.. automodule:: feast_spark.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.job\_service module
+--------------------------------
+
+.. automodule:: feast_spark.job_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.remote\_job module
+-------------------------------
+
+.. automodule:: feast_spark.remote_job
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.third_party.grpc.health.rst
+++ b/python/docs/source/feast_spark.third_party.grpc.health.rst
@@ -1,0 +1,18 @@
+feast\_spark.third\_party.grpc.health package
+=============================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.third_party.grpc.health.v1
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.third_party.grpc.health
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.third_party.grpc.health.v1.rst
+++ b/python/docs/source/feast_spark.third_party.grpc.health.v1.rst
@@ -1,0 +1,29 @@
+feast\_spark.third\_party.grpc.health.v1 package
+================================================
+
+Submodules
+----------
+
+feast\_spark.third\_party.grpc.health.v1.HealthService\_pb2 module
+------------------------------------------------------------------
+
+.. automodule:: feast_spark.third_party.grpc.health.v1.HealthService_pb2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast\_spark.third\_party.grpc.health.v1.HealthService\_pb2\_grpc module
+------------------------------------------------------------------------
+
+.. automodule:: feast_spark.third_party.grpc.health.v1.HealthService_pb2_grpc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.third_party.grpc.health.v1
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.third_party.grpc.rst
+++ b/python/docs/source/feast_spark.third_party.grpc.rst
@@ -1,0 +1,18 @@
+feast\_spark.third\_party.grpc package
+======================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.third_party.grpc.health
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.third_party.grpc
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/feast_spark.third_party.rst
+++ b/python/docs/source/feast_spark.third_party.rst
@@ -1,0 +1,18 @@
+feast\_spark.third\_party package
+=================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark.third_party.grpc
+
+Module contents
+---------------
+
+.. automodule:: feast_spark.third_party
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Feast Spark SDK's documentation!
+Feast Spark SDK's documentation!
 ===========================================
 
 .. toctree::

--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. Feast Spark SDK documentation master file, created by
+   sphinx-quickstart on Sun Mar 21 17:00:24 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Feast Spark SDK's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Client
+==================
+
+.. automodule:: feast_spark.client
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/source/modules.rst
+++ b/python/docs/source/modules.rst
@@ -1,0 +1,7 @@
+feast_spark
+===========
+
+.. toctree::
+   :maxdepth: 4
+
+   feast_spark


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently the `Feast Spark SDK` documentation isn't being published anywhere. This PR introduces proto building as part of `setup.py` and also adds Sphinx documentation configuration.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
