### PR TITLE
Support for Cassandra as online storage (WIP)

### DIFF
--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -142,10 +142,17 @@
         </dependency>
 
         <dependency>
+            <groupId>com.datastax.spark</groupId>
+            <artifactId>spark-cassandra-connector_${scala.version}</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.redislabs</groupId>
             <artifactId>spark-redis_${scala.version}</artifactId>
             <version>2.5.0</version>
         </dependency>
+
 
         <dependency>
             <groupId>io.netty</groupId>
@@ -189,6 +196,13 @@
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-kafka_${scala.version}</artifactId>
+            <version>0.38.8</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.dimafeng</groupId>
+            <artifactId>testcontainers-scala-cassandra_${scala.version}</artifactId>
             <version>0.38.8</version>
             <scope>test</scope>
         </dependency>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -38,6 +38,17 @@ object BasePipeline {
           .set("spark.redis.host", host)
           .set("spark.redis.port", port.toString)
           .set("spark.redis.ssl", ssl.toString)
+      case CassandraConfig(connection, _, properties) =>
+        conf
+          .set("spark.sql.extensions", "com.datastax.spark.connector.CassandraSparkExtensions")
+          .set("spark.cassandra.connection.host", connection.host)
+          .set("spark.cassandra.connection.port", connection.port.toString)
+          .set("spark.cassandra.output.batch.size.bytes", properties.batchSize.toString)
+          .set("spark.cassandra.output.concurrent.writes", properties.concurrentWrite.toString)
+          .set(
+            s"spark.sql.catalog.feast",
+            "com.datastax.spark.connector.datasource.CassandraCatalog"
+          )
     }
 
     jobConfig.metrics match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -81,6 +81,9 @@ object IngestionJob {
     opt[String](name = "redis")
       .action((x, c) => c.copy(store = parseJSON(x).extract[RedisConfig]))
 
+    opt[String](name = "cassandra")
+      .action((x, c) => c.copy(store = parseJSON(x).extract[CassandraConfig]))
+
     opt[String](name = "statsd")
       .action((x, c) => c.copy(metrics = Some(parseJSON(x).extract[StatsDConfig])))
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -28,6 +28,14 @@ abstract class StoreConfig
 
 case class RedisConfig(host: String, port: Int, ssl: Boolean) extends StoreConfig
 
+case class CassandraConfig(
+    connection: CassandraConnection,
+    keyspace: String,
+    properties: CassandraWriteProperties
+) extends StoreConfig
+case class CassandraConnection(host: String, port: Int)
+case class CassandraWriteProperties(batchSize: Int, concurrentWrite: Int)
+
 sealed trait MetricConfig
 
 case class StatsDConfig(host: String, port: Int) extends MetricConfig

--- a/spark/ingestion/src/test/scala/feast/ingestion/CassandraIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/CassandraIT.scala
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion
+
+import com.dimafeng.testcontainers.{CassandraContainer, ForAllTestContainer}
+import feast.ingestion.helpers.DataHelper._
+import feast.ingestion.metrics.StatsDStub
+import feast.proto.types.ValueProto.ValueType
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.{Encoder, SaveMode}
+import org.joda.time.{DateTime, Seconds}
+import org.scalacheck._
+
+case class CassandraTestRow(
+    customer: String,
+    feature1: Int,
+    feature2: Float,
+    eventTimestamp: java.sql.Timestamp
+)
+
+class CassandraIT extends SparkSpec with ForAllTestContainer {
+
+  val statsDStub = new StatsDStub
+
+  override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
+    .set("spark.metrics.conf.*.sink.statsd.port", statsDStub.port.toString)
+    .set("spark.sql.extensions", "com.datastax.spark.connector.CassandraSparkExtensions")
+    .set("spark.cassandra.connection.host", container.host)
+    .set("spark.cassandra.connection.port", container.mappedPort(9042).toString)
+    .set(
+      s"spark.sql.catalog.feast",
+      "com.datastax.spark.connector.datasource.CassandraCatalog"
+    )
+
+  override val container: CassandraContainer = CassandraContainer()
+
+  trait Scope {
+
+    statsDStub.receivedMetrics // clean the buffer
+
+    val keyspace = "feast"
+
+    val session = container.cluster.newSession()
+    session.execute(s"""
+         |DROP KEYSPACE IF EXISTS ${keyspace}
+         |""".stripMargin)
+    session.execute(s"""
+         |CREATE KEYSPACE ${keyspace} WITH REPLICATION = {
+         |'class' : 'SimpleStrategy',
+         |'replication_factor' : 1
+         |};
+         |""".stripMargin)
+
+    implicit def testRowEncoder: Encoder[CassandraTestRow] = ExpressionEncoder()
+
+    def rowGenerator(start: DateTime, end: DateTime) =
+      for {
+        customer <- Gen.uuid.map(_.toString)
+        feature1 <- Gen.choose(0, 100)
+        feature2 <- Gen.choose[Float](0, 1)
+        eventTimestamp <- Gen
+          .choose(0, Seconds.secondsBetween(start, end).getSeconds - 1)
+          .map(start.withMillisOfSecond(0).plusSeconds)
+      } yield CassandraTestRow(
+        customer,
+        feature1,
+        feature2,
+        new java.sql.Timestamp(eventTimestamp.getMillis)
+      )
+
+    val config = IngestionJobConfig(
+      featureTable = FeatureTable(
+        name = "test-fs",
+        project = "default",
+        entities = Seq(Field("customer", ValueType.Enum.STRING)),
+        features = Seq(
+          Field("feature1", ValueType.Enum.INT32),
+          Field("feature2", ValueType.Enum.FLOAT)
+        )
+      ),
+      startTime = DateTime.parse("2020-08-01"),
+      endTime = DateTime.parse("2020-09-01"),
+      metrics = Some(StatsDConfig(host = "localhost", port = statsDStub.port)),
+      store = CassandraConfig(
+        CassandraConnection(container.host, container.mappedPort(9042)),
+        keyspace,
+        CassandraWriteProperties(1024, 5)
+      )
+    )
+  }
+
+  "Parquet source file" should "be ingested in cassandra" in new Scope {
+    val gen      = rowGenerator(DateTime.parse("2020-08-01"), DateTime.parse("2020-09-01"))
+    val rows     = generateRows(gen, 1000)
+    val tempPath = storeAsParquet(sparkSession, rows)
+    val configWithOfflineSource = config.copy(
+      source = FileSource(tempPath, Map.empty, "eventTimestamp", datePartitionColumn = Some("date"))
+    )
+
+    BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
+
+    session
+      .execute(s"SELECT COUNT(1) AS cnt FROM ${keyspace}.default_customer")
+      .one()
+      .getLong("cnt") should equal(1000)
+  }
+
+}


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@go-jek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This is a work in progress PR to explore the feasibility of Cassandra as an alternative to Redis cluster for online storage.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
