### PR TITLE
Cassandra as sink option for ingestion job

### DIFF
--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -114,6 +114,12 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: BigTable Instance ID
     BIGTABLE_INSTANCE: Optional[str] = ""
 
+    #: Cassandra host. Can be a comma separated string
+    CASSANDRA_HOST: Optional[str] = ""
+
+    #: Cassandra port
+    CASSANDRA_PORT: Optional[str] = ""
+
     #: Enable or disable StatsD
     STATSD_ENABLED: str = "False"
 

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -333,6 +333,8 @@ class IngestionJobParameters(SparkJobParameters):
         redis_ssl: Optional[bool] = None,
         bigtable_project: Optional[str] = None,
         bigtable_instance: Optional[str] = None,
+        cassandra_host: Optional[str] = None,
+        cassandra_port: Optional[int] = None,
         statsd_host: Optional[str] = None,
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
@@ -347,6 +349,8 @@ class IngestionJobParameters(SparkJobParameters):
         self._redis_ssl = redis_ssl
         self._bigtable_project = bigtable_project
         self._bigtable_instance = bigtable_instance
+        self._cassandra_host = cassandra_host
+        self._cassandra_port = cassandra_port
         self._statsd_host = statsd_host
         self._statsd_port = statsd_port
         self._deadletter_path = deadletter_path
@@ -360,6 +364,9 @@ class IngestionJobParameters(SparkJobParameters):
         return dict(
             project_id=self._bigtable_project, instance_id=self._bigtable_instance
         )
+
+    def _get_cassandra_config(self):
+        return dict(host=self._cassandra_host, port=self._cassandra_port)
 
     def _get_statsd_config(self):
         return (
@@ -394,6 +401,9 @@ class IngestionJobParameters(SparkJobParameters):
         if self._bigtable_project and self._bigtable_instance:
             args.extend(["--bigtable", json.dumps(self._get_bigtable_config())])
 
+        if self._cassandra_host and self._cassandra_port:
+            args.extend(["--cassandra", json.dumps(self._get_cassandra_config())])
+
         if self._get_statsd_config():
             args.extend(["--statsd", json.dumps(self._get_statsd_config())])
 
@@ -427,6 +437,8 @@ class BatchIngestionJobParameters(IngestionJobParameters):
         redis_ssl: Optional[bool],
         bigtable_project: Optional[str],
         bigtable_instance: Optional[str],
+        cassandra_host: Optional[str] = None,
+        cassandra_port: Optional[int] = None,
         statsd_host: Optional[str] = None,
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
@@ -441,6 +453,8 @@ class BatchIngestionJobParameters(IngestionJobParameters):
             redis_ssl,
             bigtable_project,
             bigtable_instance,
+            cassandra_host,
+            cassandra_port,
             statsd_host,
             statsd_port,
             deadletter_path,
@@ -481,6 +495,8 @@ class StreamIngestionJobParameters(IngestionJobParameters):
         redis_ssl: Optional[bool],
         bigtable_project: Optional[str],
         bigtable_instance: Optional[str],
+        cassandra_host: Optional[str] = None,
+        cassandra_port: Optional[int] = None,
         statsd_host: Optional[str] = None,
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
@@ -497,6 +513,8 @@ class StreamIngestionJobParameters(IngestionJobParameters):
             redis_ssl,
             bigtable_project,
             bigtable_instance,
+            cassandra_host,
+            cassandra_port,
             statsd_host,
             statsd_port,
             deadletter_path,

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -276,6 +276,9 @@ def start_offline_to_online_ingestion(
             redis_ssl=client.config.getboolean(opt.REDIS_SSL),
             bigtable_project=client.config.get(opt.BIGTABLE_PROJECT),
             bigtable_instance=client.config.get(opt.BIGTABLE_INSTANCE),
+            cassandra_host=client.config.get(opt.CASSANDRA_HOST),
+            cassandra_port=bool(client.config.get(opt.CASSANDRA_HOST))
+            and client.config.getint(opt.CASSANDRA_PORT),
             statsd_host=(
                 client.config.getboolean(opt.STATSD_ENABLED)
                 and client.config.get(opt.STATSD_HOST)

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -178,6 +178,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.datastax.spark</groupId>
+            <artifactId>spark-cassandra-connector_${scala.version}</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>4.1.52.Final</version>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -42,7 +42,7 @@ object BasePipeline {
         conf
           .set("spark.bigtable.projectId", projectId)
           .set("spark.bigtable.instanceId", instanceId)
-      case CassandraConfig(connection, _, properties) =>
+      case CassandraConfig(connection, keyspace, properties) =>
         conf
           .set("spark.sql.extensions", "com.datastax.spark.connector.CassandraSparkExtensions")
           .set("spark.cassandra.connection.host", connection.host)
@@ -53,6 +53,7 @@ object BasePipeline {
             s"spark.sql.catalog.feast",
             "com.datastax.spark.connector.datasource.CassandraCatalog"
           )
+          .set("feast.store.cassandra.keyspace", keyspace)
     }
 
     jobConfig.metrics match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -42,6 +42,17 @@ object BasePipeline {
         conf
           .set("spark.bigtable.projectId", projectId)
           .set("spark.bigtable.instanceId", instanceId)
+      case CassandraConfig(connection, _, properties) =>
+        conf
+          .set("spark.sql.extensions", "com.datastax.spark.connector.CassandraSparkExtensions")
+          .set("spark.cassandra.connection.host", connection.host)
+          .set("spark.cassandra.connection.port", connection.port.toString)
+          .set("spark.cassandra.output.batch.size.bytes", properties.batchSize.toString)
+          .set("spark.cassandra.output.concurrent.writes", properties.concurrentWrite.toString)
+          .set(
+            s"spark.sql.catalog.feast",
+            "com.datastax.spark.connector.datasource.CassandraCatalog"
+          )
     }
 
     jobConfig.metrics match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -76,7 +76,7 @@ object BatchPipeline extends BasePipeline {
       .map(metrics.incrementRead)
       .filter(rowValidator.allChecks)
 
-    val writerWithCommonOptions = validRows.write
+    validRows.write
       .format(config.store match {
         case _: RedisConfig     => "feast.ingestion.stores.redis"
         case _: BigTableConfig  => "feast.ingestion.stores.bigtable"
@@ -87,15 +87,7 @@ object BatchPipeline extends BasePipeline {
       .option("project_name", featureTable.project)
       .option("timestamp_column", config.source.eventTimestampColumn)
       .option("max_age", config.featureTable.maxAge.getOrElse(0L))
-
-    val writer = config.store match {
-      case storeConfig: CassandraConfig =>
-        writerWithCommonOptions
-          .option("keyspace", storeConfig.keyspace)
-      case _ => writerWithCommonOptions
-    }
-
-    writer.save()
+      .save()
 
     config.deadLetterPath foreach { path =>
       projected

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -84,6 +84,9 @@ object IngestionJob {
     opt[String](name = "bigtable")
       .action((x, c) => c.copy(store = parseJSON(x).camelizeKeys.extract[BigTableConfig]))
 
+    opt[String](name = "cassandra")
+      .action((x, c) => c.copy(store = parseJSON(x).extract[CassandraConfig]))
+
     opt[String](name = "statsd")
       .action((x, c) => c.copy(metrics = Some(parseJSON(x).extract[StatsDConfig])))
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -28,6 +28,13 @@ abstract class StoreConfig
 
 case class RedisConfig(host: String, port: Int, ssl: Boolean)    extends StoreConfig
 case class BigTableConfig(projectId: String, instanceId: String) extends StoreConfig
+case class CassandraConfig(
+    connection: CassandraConnection,
+    keyspace: String,
+    properties: CassandraWriteProperties
+) extends StoreConfig
+case class CassandraConnection(host: String, port: Int)
+case class CassandraWriteProperties(batchSize: Int, concurrentWrite: Int)
 
 sealed trait MetricConfig
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -31,7 +31,7 @@ case class BigTableConfig(projectId: String, instanceId: String) extends StoreCo
 case class CassandraConfig(
     connection: CassandraConnection,
     keyspace: String,
-    properties: CassandraWriteProperties
+    properties: CassandraWriteProperties = CassandraWriteProperties(1024, 5)
 ) extends StoreConfig
 case class CassandraConnection(host: String, port: Int)
 case class CassandraWriteProperties(batchSize: Int, concurrentWrite: Int)

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -107,20 +107,29 @@ object StreamingPipeline extends BasePipeline with Serializable {
 
         implicit val rowEncoder: Encoder[Row] = RowEncoder(rowsAfterValidation.schema)
 
-        rowsAfterValidation
+        val writerWithCommonOptions = rowsAfterValidation
           .map(metrics.incrementRead)
           .filter(if (config.doNotIngestInvalidRows) expr("_isValid") else rowValidator.allChecks)
           .write
           .format(config.store match {
-            case _: RedisConfig    => "feast.ingestion.stores.redis"
-            case _: BigTableConfig => "feast.ingestion.stores.bigtable"
+            case _: RedisConfig     => "feast.ingestion.stores.redis"
+            case _: BigTableConfig  => "feast.ingestion.stores.bigtable"
+            case _: CassandraConfig => "feast.ingestion.stores.cassandra"
           })
           .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
           .option("namespace", featureTable.name)
           .option("project_name", featureTable.project)
           .option("timestamp_column", config.source.eventTimestampColumn)
           .option("max_age", config.featureTable.maxAge.getOrElse(0L))
-          .save()
+
+        val writer = config.store match {
+          case storeConfig: CassandraConfig =>
+            writerWithCommonOptions
+              .option("keyspace", storeConfig.keyspace)
+          case _ => writerWithCommonOptions
+        }
+
+        writer.save()
 
         config.deadLetterPath match {
           case Some(path) =>

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.functions.{col, length, struct, udf}
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.sql.types.{StringType, StructType}
-import feast.ingestion.stores.bigtable.serialization.Serializer
+import feast.ingestion.stores.serialization.Serializer
 import org.apache.hadoop.security.UserGroupInformation
 
 class BigTableSinkRelation(

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/CassandraSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/CassandraSinkRelation.scala
@@ -70,7 +70,7 @@ class CassandraSinkRelation(
     sanitizedForCassandra(s"${config.projectName}__${entities}")
   }
 
-  val keyspace = config.keyspace
+  val keyspace = sqlContext.sparkContext.getConf.get("feast.store.cassandra.keyspace")
 
   val sparkCatalog = "feast"
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/CassandraSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/CassandraSinkRelation.scala
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.stores.cassandra
+
+import feast.ingestion.stores.serialization.Serializer
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.{col, lit, struct, udf}
+import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
+import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+class CassandraSinkRelation(
+    override val sqlContext: SQLContext,
+    val serializer: Serializer,
+    val config: SparkCassandraConfig
+) extends BaseRelation
+    with InsertableRelation
+    with Serializable {
+  override def schema: StructType = ???
+
+  override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+
+    val featureFields = data.schema.fields
+      .filterNot(f => isSystemColumn(f.name))
+
+    val featureColumns = featureFields.map(f => col(f.name))
+
+    val entityColumns = config.entityColumns.map(c => col(c).cast(StringType))
+
+    val schemaReference = serializer.schemaReference(StructType(featureFields))
+
+    data
+      .select(
+        joinEntityKey(struct(entityColumns: _*)).alias("key"),
+        serializer.serializeData(struct(featureColumns: _*)).alias(columnName),
+        col(config.timestampColumn).alias("ts")
+      )
+      .withColumn("schema_ref", lit(schemaReference))
+      .writeTo(fullTableReference)
+      .option("writeTime", "ts")
+      .append()
+  }
+
+  def sanitizedForCassandra(expr: String): String = {
+    expr.replace('-', '_')
+  }
+
+  val tableName = {
+    val entities = config.entityColumns.mkString("_")
+    sanitizedForCassandra(s"${config.projectName}_${entities}")
+  }
+
+  val keyspace = config.keyspace
+
+  val sparkCatalog = "feast"
+
+  val fullTableReference = s"${sparkCatalog}.${keyspace}.`${tableName}`"
+
+  val columnName = sanitizedForCassandra(config.namespace)
+
+  val schemaTableName = s"${sparkCatalog}.${keyspace}.feast_schema_reference"
+
+  def createTable(): Unit = {
+
+    sqlContext.sql(s"""
+    |CREATE TABLE IF NOT EXISTS ${fullTableReference}
+    |(key BINARY, schema_ref BINARY)
+    |USING cassandra
+    |PARTITIONED BY (key)
+    |""".stripMargin)
+
+    sqlContext.sql(s"""
+         |ALTER TABLE ${fullTableReference}
+         |ADD COLUMNS (${columnName} BINARY)
+         |""".stripMargin)
+
+  }
+
+  private def joinEntityKey: UserDefinedFunction = udf { r: Row =>
+    ((0 until r.size)).map(r.getString).mkString("#").getBytes
+  }
+
+  private def isSystemColumn(name: String) =
+    (config.entityColumns ++ Seq(config.timestampColumn)).contains(name)
+
+  def saveWriteSchema(data: DataFrame) = {
+    sqlContext.sql(s"""
+      |CREATE TABLE IF NOT EXISTS ${schemaTableName}
+      |(schema_ref BINARY, avro_schema BINARY)
+      |USING cassandra
+      |PARTITIONED BY (schema_ref)
+      |""".stripMargin)
+
+    val featureFields = data.schema.fields
+      .filterNot(f => isSystemColumn(f.name))
+    val featureSchema    = StructType(featureFields)
+    val key              = serializer.schemaReference(featureSchema)
+    val serializedSchema = serializer.serializeSchema(featureSchema).getBytes
+
+    import sqlContext.sparkSession.implicits._
+    val schemaData = List((key, serializedSchema)).toDF("schema_ref", "avro_schema")
+
+    schemaData.writeTo(schemaTableName).append()
+  }
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/SparkCassandraConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/SparkCassandraConfig.scala
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.stores.cassandra
+
+case class SparkCassandraConfig(
+    keyspace: String,
+    namespace: String,
+    projectName: String,
+    entityColumns: Array[String],
+    timestampColumn: String,
+    maxAge: Long
+)
+
+object SparkCassandraConfig {
+  val KEYSPACE       = "keyspace"
+  val NAMESPACE      = "namespace"
+  val ENTITY_COLUMNS = "entity_columns"
+  val TS_COLUMN      = "timestamp_column"
+  val PROJECT_NAME   = "project_name"
+  val MAX_AGE        = "max_age"
+
+  def parse(parameters: Map[String, String]): SparkCassandraConfig =
+    SparkCassandraConfig(
+      keyspace = parameters.getOrElse(KEYSPACE, ""),
+      namespace = parameters.getOrElse(NAMESPACE, ""),
+      projectName = parameters.getOrElse(PROJECT_NAME, "default"),
+      entityColumns = parameters.getOrElse(ENTITY_COLUMNS, "").split(","),
+      timestampColumn = parameters.getOrElse(TS_COLUMN, "event_timestamp"),
+      maxAge = parameters.get(MAX_AGE).map(_.toLong).getOrElse(0)
+    )
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/SparkCassandraConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/SparkCassandraConfig.scala
@@ -17,7 +17,6 @@
 package feast.ingestion.stores.cassandra
 
 case class SparkCassandraConfig(
-    keyspace: String,
     namespace: String,
     projectName: String,
     entityColumns: Array[String],
@@ -26,7 +25,6 @@ case class SparkCassandraConfig(
 )
 
 object SparkCassandraConfig {
-  val KEYSPACE       = "keyspace"
   val NAMESPACE      = "namespace"
   val ENTITY_COLUMNS = "entity_columns"
   val TS_COLUMN      = "timestamp_column"
@@ -35,7 +33,6 @@ object SparkCassandraConfig {
 
   def parse(parameters: Map[String, String]): SparkCassandraConfig =
     SparkCassandraConfig(
-      keyspace = parameters.getOrElse(KEYSPACE, ""),
       namespace = parameters.getOrElse(NAMESPACE, ""),
       projectName = parameters.getOrElse(PROJECT_NAME, "default"),
       entityColumns = parameters.getOrElse(ENTITY_COLUMNS, "").split(","),

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/serialization/Serializer.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/serialization/Serializer.scala
@@ -14,25 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.ingestion.stores.bigtable.serialization
+package feast.ingestion.stores.serialization
 
-import com.google.common.hash.Hashing
 import org.apache.spark.sql.Column
-import org.apache.spark.sql.avro.SchemaConverters
-import org.apache.spark.sql.avro.functions.to_avro
 import org.apache.spark.sql.types.StructType
 
-class AvroSerializer extends Serializer {
-  override type SchemaType = String
+trait Serializer {
+  type SchemaType
 
-  def convertSchema(schema: StructType): String = {
-    val avroSchema = SchemaConverters.toAvroType(schema)
-    avroSchema.toString
-  }
+  def convertSchema(schema: StructType): SchemaType
 
-  def schemaReference(schema: String): Array[Byte] = {
-    Hashing.murmur3_32().hashBytes(schema.getBytes).asBytes()
-  }
+  def schemaReference(schema: SchemaType): Array[Byte]
 
-  def serializeData(schema: String): Column => Column = to_avro(_, schema)
+  def serializeData(schema: SchemaType): Column => Column
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/CassandraIngestionSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/CassandraIngestionSpec.scala
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import feast.ingestion.helpers.DataHelper.{generateDistinctRows, rowGenerator, storeAsParquet}
+import feast.ingestion.helpers.TestRow
+import feast.proto.types.ValueProto.ValueType
+import org.apache.avro.Schema
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+import org.apache.avro.io.DecoderFactory
+import org.apache.spark.SparkConf
+import org.joda.time.DateTime
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.sql.Timestamp
+import java.time.{Duration, Instant}
+
+class CassandraIngestionSpec extends SparkSpec with ForAllTestContainer {
+
+  override val container = GenericContainer(
+    "cassandra:3.11.10",
+    exposedPorts = Seq(9042),
+    waitStrategy = Wait
+      .forListeningPort()
+      .withStartupTimeout(Duration.ofSeconds(120))
+  )
+
+  override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
+    .set("spark.sql.extensions", "com.datastax.spark.connector.CassandraSparkExtensions")
+    .set("spark.cassandra.connection.host", container.host)
+    .set("spark.cassandra.connection.port", container.mappedPort(9042).toString)
+    .set(
+      s"spark.sql.catalog.feast",
+      "com.datastax.spark.connector.datasource.CassandraCatalog"
+    )
+    .set("spark.cassandra.connection.localDC", "datacenter1")
+
+  trait Scope {
+    val keyspace = "feast"
+
+    val config = IngestionJobConfig(
+      featureTable = FeatureTable(
+        name = "test-fs",
+        project = "default",
+        entities = Seq(Field("customer", ValueType.Enum.STRING)),
+        features = Seq(
+          Field("feature1", ValueType.Enum.INT32),
+          Field("feature2", ValueType.Enum.FLOAT)
+        )
+      ),
+      startTime = DateTime.parse("2020-08-01"),
+      endTime = DateTime.parse("2020-09-01"),
+      store = CassandraConfig(
+        CassandraConnection(container.host, container.mappedPort(9042)),
+        keyspace,
+        CassandraWriteProperties(1024, 5)
+      )
+    )
+
+    val gen = rowGenerator(DateTime.parse("2020-08-01"), DateTime.parse("2020-09-01"))
+
+  }
+
+  def decodeAvroValue(input: Array[Byte], jsonFormatSchema: String): GenericRecord = {
+    val schema      = new Schema.Parser().parse(jsonFormatSchema)
+    val reader      = new GenericDatumReader[Any](schema)
+    var result: Any = null
+
+    val decoder = DecoderFactory.get().binaryDecoder(input, 0, input.length, null)
+    result = reader.read(result, decoder)
+    result.asInstanceOf[GenericRecord]
+  }
+
+  "Dataset" should "be ingested in cassandra" in new Scope {
+    sparkSession.sql(
+      "CREATE DATABASE IF NOT EXISTS feast.feast WITH DBPROPERTIES (class='SimpleStrategy',replication_factor='1')"
+    )
+    val rows     = generateDistinctRows(gen, 1000, (_: TestRow).customer).filterNot(_.customer.isEmpty)
+    val tempPath = storeAsParquet(sparkSession, rows)
+    val configWithOfflineSource = config.copy(
+      source = FileSource(tempPath, Map.empty, "eventTimestamp")
+    )
+
+    BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)
+    val avroSchema = sparkSession
+      .sql(
+        "SELECT schema_ref, avro_schema FROM feast.feast.feast_schema_reference"
+      )
+      .collect()
+      .map(row => row.getAs[Array[Byte]](0).toSeq -> new String(row.getAs[Array[Byte]](1)))
+      .toMap
+
+    val storedRows = sparkSession
+      .sql(
+        "SELECT key, test_fs, schema_ref, writeTime(test_fs) FROM feast.feast.default_customer"
+      )
+      .collect()
+      .map { row =>
+        val record = decodeAvroValue(
+          row.getAs[Array[Byte]](1),
+          avroSchema.get(row.getAs[Array[Byte]](2).toSeq).get
+        )
+
+        TestRow(
+          new String(row.getAs[Array[Byte]](0)),
+          record.get("feature1").asInstanceOf[Integer],
+          record.get("feature2").asInstanceOf[Float],
+          Timestamp.from(Instant.ofEpochMilli(row.getLong(3)))
+        )
+      }
+
+    storedRows should contain allElementsOf rows
+
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/CassandraIngestionSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/CassandraIngestionSpec.scala
@@ -107,7 +107,7 @@ class CassandraIngestionSpec extends SparkSpec with ForAllTestContainer {
 
     val storedRows = sparkSession
       .sql(
-        "SELECT key, test_fs, schema_ref, writeTime(test_fs) FROM feast.feast.default_customer"
+        "SELECT key, test_fs, test_fs__schema_ref, writeTime(test_fs) FROM feast.feast.default__customer"
       )
       .collect()
       .map { row =>

--- a/spark/ingestion/src/test/scala/feast/ingestion/CassandraIngestionSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/CassandraIngestionSpec.scala
@@ -40,6 +40,8 @@ class CassandraIngestionSpec extends SparkSpec with ForAllTestContainer {
       .withStartupTimeout(Duration.ofSeconds(120))
   )
 
+  val keyspace = "feast"
+
   override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
     .set("spark.sql.extensions", "com.datastax.spark.connector.CassandraSparkExtensions")
     .set("spark.cassandra.connection.host", container.host)
@@ -49,9 +51,9 @@ class CassandraIngestionSpec extends SparkSpec with ForAllTestContainer {
       "com.datastax.spark.connector.datasource.CassandraCatalog"
     )
     .set("spark.cassandra.connection.localDC", "datacenter1")
+    .set("feast.store.cassandra.keyspace", keyspace)
 
   trait Scope {
-    val keyspace = "feast"
 
     val config = IngestionJobConfig(
       featureTable = FeatureTable(
@@ -113,7 +115,7 @@ class CassandraIngestionSpec extends SparkSpec with ForAllTestContainer {
       .map { row =>
         val record = decodeAvroValue(
           row.getAs[Array[Byte]](1),
-          avroSchema.get(row.getAs[Array[Byte]](2).toSeq).get
+          avroSchema(row.getAs[Array[Byte]](2).toSeq)
         )
 
         TestRow(


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->t
**What this PR does / why we need it**:
Adding Cassandra as sink option for ingestion job.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Cassandra will be available as an alternative online storage.
```
