### PR TITLE
Fix avro serialization: reuse generated schema in advance

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -119,7 +119,7 @@ class BigTableSinkRelation(
     val featureSchema = StructType(featureFields)
 
     val schema = serializer.convertSchema(featureSchema)
-    val key = schemaKeyPrefix.getBytes ++ serializer.schemaReference(schema)
+    val key    = schemaKeyPrefix.getBytes ++ serializer.schemaReference(schema)
 
     val put       = new Put(key)
     val qualifier = "avro".getBytes

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -94,15 +94,16 @@ class BigTableSinkRelation(
     val featureFields = data.schema.fields
       .filterNot(f => isSystemColumn(f.name))
 
-    val featureColumns = featureFields.map(f => col(f.name))
+    val featureColumns = featureFields.map(f => data(f.name))
 
-    val entityColumns   = config.entityColumns.map(c => col(c).cast(StringType))
-    val schemaReference = serializer.schemaReference(StructType(featureFields))
+    val entityColumns   = config.entityColumns.map(c => data(c).cast(StringType))
+    val schema          = serializer.convertSchema(StructType(featureFields))
+    val schemaReference = serializer.schemaReference(schema)
 
     data
       .select(
         joinEntityKey(struct(entityColumns: _*)).alias("key"),
-        serializer.serializeData(struct(featureColumns: _*)).alias("value"),
+        serializer.serializeData(schema)(struct(featureColumns: _*)).alias("value"),
         col(config.timestampColumn).alias("ts")
       )
       .where(length(col("key")) > 0)
@@ -117,12 +118,12 @@ class BigTableSinkRelation(
       .filterNot(f => isSystemColumn(f.name))
     val featureSchema = StructType(featureFields)
 
-    val key              = schemaKeyPrefix.getBytes ++ serializer.schemaReference(featureSchema)
-    val serializedSchema = serializer.serializeSchema(featureSchema).getBytes
+    val schema = serializer.convertSchema(featureSchema)
+    val key = schemaKeyPrefix.getBytes ++ serializer.schemaReference(schema)
 
     val put       = new Put(key)
     val qualifier = "avro".getBytes
-    put.addColumn(metadataColumnFamily.getBytes, qualifier, serializedSchema)
+    put.addColumn(metadataColumnFamily.getBytes, qualifier, schema.asInstanceOf[String].getBytes)
 
     val btConn = BigtableConfiguration.connect(hadoopConfig)
     try {

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/AvroSerializer.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/AvroSerializer.scala
@@ -23,14 +23,16 @@ import org.apache.spark.sql.avro.functions.to_avro
 import org.apache.spark.sql.types.StructType
 
 class AvroSerializer extends Serializer {
-  def serializeSchema(schema: StructType): String = {
+  override type SchemaType = String
+
+  def convertSchema(schema: StructType): String = {
     val avroSchema = SchemaConverters.toAvroType(schema)
     avroSchema.toString
   }
 
-  def schemaReference(schema: StructType): Array[Byte] = {
-    Hashing.murmur3_32().hashBytes(serializeSchema(schema).getBytes).asBytes()
+  def schemaReference(schema: String): Array[Byte] = {
+    Hashing.murmur3_32().hashBytes(schema.getBytes).asBytes()
   }
 
-  def serializeData: Column => Column = to_avro
+  def serializeData(schema: String): Column => Column = to_avro(_, schema)
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/Serializer.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/serialization/Serializer.scala
@@ -20,9 +20,11 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.types.StructType
 
 trait Serializer {
-  def serializeSchema(schema: StructType): String
+  type SchemaType
 
-  def schemaReference(schema: StructType): Array[Byte]
+  def convertSchema(schema: StructType): SchemaType
 
-  def serializeData: Column => Column
+  def schemaReference(schema: SchemaType): Array[Byte]
+
+  def serializeData(schema: SchemaType): Column => Column
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/validation/RowValidator.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/validation/RowValidator.scala
@@ -31,5 +31,5 @@ class RowValidator(featureTable: FeatureTable, timestampColumn: String) extends 
     col(timestampColumn).isNotNull
 
   def allChecks: Column =
-    allEntitiesPresent && atLeastOneFeatureNotNull && timestampPresent
+    allEntitiesPresent && timestampPresent
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR explicitly passes Avro schema to avro serializer since column types (specifically `nullable`property) may differ in pipeline compile & run times.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
