### PR TITLE
Add project whitelist

### DIFF
--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -71,13 +71,6 @@ class Client:
         return self.config.exists(opt.JOB_SERVICE_URL)
 
     @property
-    def _whitelisted_projects(self) -> Optional[List[str]]:
-        if self.config.exists(opt.WHITELISTED_PROJECTS):
-            whitelisted_projects = self.config.get(opt.WHITELISTED_PROJECTS)
-            return whitelisted_projects.split(",")
-        return None
-
-    @property
     def _job_service(self):
         """
         Creates or returns the gRPC Feast Job Service Stub
@@ -99,12 +92,6 @@ class Client:
             )
             self._job_service_service_stub = JobServiceStub(channel)
         return self._job_service_service_stub
-
-    def is_whitelisted(self, project: str):
-        # Whitelisted projects not specified, allow all projects
-        if not self._whitelisted_projects:
-            return True
-        return project in self._whitelisted_projects
 
     def get_historical_features(
         self,

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -71,6 +71,13 @@ class Client:
         return self.config.exists(opt.JOB_SERVICE_URL)
 
     @property
+    def _whitelisted_projects(self) -> Optional[List[str]]:
+        if self.config.exists(opt.WHITELISTED_PROJECTS):
+            whitelisted_projects = self.config.get(opt.WHITELISTED_PROJECTS)
+            return whitelisted_projects.split(",")
+        return None
+
+    @property
     def _job_service(self):
         """
         Creates or returns the gRPC Feast Job Service Stub
@@ -92,6 +99,12 @@ class Client:
             )
             self._job_service_service_stub = JobServiceStub(channel)
         return self._job_service_service_stub
+
+    def is_whitelisted(self, project: str):
+        # Whitelisted projects not specified, allow all projects
+        if not self._whitelisted_projects:
+            return True
+        return project in self._whitelisted_projects
 
     def get_historical_features(
         self,

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -157,6 +157,9 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Log path of EMR cluster
     EMR_LOG_LOCATION: Optional[str] = None
 
+    #: Whitelisted Feast projects
+    WHITELISTED_PROJECTS: Optional[str] = None
+
     def defaults(self):
         return {
             k: getattr(self, k)

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -363,11 +363,15 @@ def ensure_stream_ingestion_jobs(client: Client, all_projects: bool):
         else [client.feature_store.project]
     )
     filtered_projects = []
-    if client._job_service._whitelisted_projects:
-        for project in projects:
-            if project in client._job_service._whitelisted_projects():
-                filtered_projects.append(project)
-    projects = filtered_projects
+    if client.config.exists(opt.WHITELISTED_PROJECTS):
+        whitelisted_projects = client.config.get(opt.WHITELISTED_PROJECTS)
+        if whitelisted_projects:
+            whitelisted_projects = whitelisted_projects.split(",")
+            filtered_projects = [
+                project for project in projects if project in whitelisted_projects
+            ]
+    if filtered_projects:
+        projects = filtered_projects
 
     expected_job_hash_to_tables = _get_expected_job_hash_to_tables(client, projects)
 

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -362,16 +362,13 @@ def ensure_stream_ingestion_jobs(client: Client, all_projects: bool):
         if all_projects
         else [client.feature_store.project]
     )
-    filtered_projects = []
     if client.config.exists(opt.WHITELISTED_PROJECTS):
         whitelisted_projects = client.config.get(opt.WHITELISTED_PROJECTS)
         if whitelisted_projects:
             whitelisted_projects = whitelisted_projects.split(",")
-            filtered_projects = [
+            projects = [
                 project for project in projects if project in whitelisted_projects
             ]
-    if filtered_projects:
-        projects = filtered_projects
 
     expected_job_hash_to_tables = _get_expected_job_hash_to_tables(client, projects)
 

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -362,12 +362,12 @@ def ensure_stream_ingestion_jobs(client: Client, all_projects: bool):
         if all_projects
         else [client.feature_store.project]
     )
+    filtered_projects = []
     if client._job_service._whitelisted_projects:
-        projects = [
-            project
-            for project in projects
-            if project in client._job_service._whitelisted_projects
-        ]
+        for project in projects:
+            if project in client._job_service._whitelisted_projects():
+                filtered_projects.append(project)
+    projects = filtered_projects
 
     expected_job_hash_to_tables = _get_expected_job_hash_to_tables(client, projects)
 

--- a/python/tests/test_streaming_job_scheduling.py
+++ b/python/tests/test_streaming_job_scheduling.py
@@ -2,7 +2,7 @@ import copy
 import hashlib
 import json
 from datetime import datetime
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -28,11 +28,14 @@ def feast_client():
 
 @pytest.fixture
 def spark_client(feast_client):
-    c = Client(feast_client)
-    c.list_jobs = Mock()
-    c.start_stream_to_online_ingestion = Mock()
+    with patch("feast_spark.client.Client._job_service") as job_service:
+        job_service._whitelisted_projects.return_value = ["default"]
 
-    yield c
+        c = Client(feast_client)
+        c.list_jobs = Mock()
+        c.start_stream_to_online_ingestion = Mock()
+
+        yield c
 
 
 @pytest.fixture
@@ -193,22 +196,24 @@ def test_stopping_running_job(spark_client, feature_table):
 def test_restarting_failed_jobs(feature_table):
     """ If configured - restart failed jobs """
 
-    feast_client = FeastClient(
-        job_service_pause_between_jobs=0, job_service_retry_failed_jobs=True
-    )
-    feast_client.list_projects = Mock(return_value=["default"])
-    feast_client.list_feature_tables = Mock()
+    with patch("feast_spark.client.Client._job_service") as job_service:
+        feast_client = FeastClient(
+            job_service_pause_between_jobs=0, job_service_retry_failed_jobs=True
+        )
+        feast_client.list_projects = Mock(return_value=["default"])
+        feast_client.list_feature_tables = Mock()
 
-    spark_client = Client(feast_client)
-    spark_client.list_jobs = Mock()
-    spark_client.start_stream_to_online_ingestion = Mock()
+        spark_client = Client(feast_client)
+        spark_client.list_jobs = Mock()
+        spark_client.start_stream_to_online_ingestion = Mock()
+        job_service._whitelisted_projects.return_value = ["default"]
 
-    spark_client.feature_store.list_feature_tables.return_value = [feature_table]
-    spark_client.list_jobs.return_value = []
+        spark_client.feature_store.list_feature_tables.return_value = [feature_table]
+        spark_client.list_jobs.return_value = []
 
-    ensure_stream_ingestion_jobs(spark_client, all_projects=True)
+        ensure_stream_ingestion_jobs(spark_client, all_projects=True)
 
-    spark_client.list_jobs.assert_called_once_with(include_terminated=False)
-    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
-        feature_table, [], project="default"
-    )
+        spark_client.list_jobs.assert_called_once_with(include_terminated=False)
+        spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+            feature_table, [], project="default"
+        )

--- a/python/tests/test_streaming_job_scheduling.py
+++ b/python/tests/test_streaming_job_scheduling.py
@@ -20,7 +20,7 @@ from feast_spark.pyspark.launcher import _feature_table_to_argument, _source_to_
 @pytest.fixture
 def feast_client():
     c = FeastClient(job_service_pause_between_jobs=0)
-    c.list_projects = Mock(return_value=["default"])
+    c.list_projects = Mock(return_value=["default", "ride", "invalid_project"])
     c.list_feature_tables = Mock()
 
     yield c
@@ -29,7 +29,7 @@ def feast_client():
 @pytest.fixture
 def spark_client(feast_client):
     with patch("feast_spark.client.Client._job_service") as job_service:
-        job_service._whitelisted_projects.return_value = ["default"]
+        job_service._whitelisted_projects.return_value = ["default", "ride"]
 
         c = Client(feast_client)
         c.list_jobs = Mock()
@@ -54,15 +54,18 @@ def feature_table():
 
 
 class SimpleStreamingIngestionJob(StreamIngestionJob):
-    def __init__(self, id: str, feature_table: FeatureTable, status: SparkJobStatus):
+    def __init__(
+        self, id: str, project: str, feature_table: FeatureTable, status: SparkJobStatus
+    ):
         self._id = id
         self._feature_table = feature_table
+        self._project = project
         self._status = status
         self._hash = hash
 
     def get_hash(self) -> str:
         source = _source_to_argument(self._feature_table.stream_source, Config())
-        feature_table = _feature_table_to_argument(None, "default", self._feature_table)  # type: ignore
+        feature_table = _feature_table_to_argument(None, self._project, self._feature_table)  # type: ignore
 
         job_json = json.dumps(
             {"source": source, "feature_table": feature_table}, sort_keys=True,
@@ -93,18 +96,21 @@ def test_new_job_creation(spark_client, feature_table):
 
     ensure_stream_ingestion_jobs(spark_client, all_projects=True)
 
-    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
-        feature_table, [], project="default"
-    )
+    assert spark_client.start_stream_to_online_ingestion.call_count == 2
 
 
 def test_no_changes(spark_client, feature_table):
     """ Feature Table spec is the same """
 
-    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.IN_PROGRESS)
+    job = SimpleStreamingIngestionJob(
+        "", "default", feature_table, SparkJobStatus.IN_PROGRESS
+    )
+    job2 = SimpleStreamingIngestionJob(
+        "", "ride", feature_table, SparkJobStatus.IN_PROGRESS
+    )
 
     spark_client.feature_store.list_feature_tables.return_value = [feature_table]
-    spark_client.list_jobs.return_value = [job]
+    spark_client.list_jobs.return_value = [job, job2]
 
     ensure_stream_ingestion_jobs(spark_client, all_projects=True)
 
@@ -117,7 +123,9 @@ def test_update_existing_job(spark_client, feature_table):
 
     new_ft = copy.deepcopy(feature_table)
     new_ft.stream_source._kafka_options.topic = "new_t"
-    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.IN_PROGRESS)
+    job = SimpleStreamingIngestionJob(
+        "", "default", feature_table, SparkJobStatus.IN_PROGRESS
+    )
 
     spark_client.feature_store.list_feature_tables.return_value = [new_ft]
     spark_client.list_jobs.return_value = [job]
@@ -125,9 +133,7 @@ def test_update_existing_job(spark_client, feature_table):
     ensure_stream_ingestion_jobs(spark_client, all_projects=True)
 
     assert job.get_status() == SparkJobStatus.COMPLETED
-    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
-        new_ft, [], project="default"
-    )
+    assert spark_client.start_stream_to_online_ingestion.call_count == 2
 
 
 def test_not_cancelling_starting_job(spark_client, feature_table):
@@ -135,7 +141,9 @@ def test_not_cancelling_starting_job(spark_client, feature_table):
 
     new_ft = copy.deepcopy(feature_table)
     new_ft.stream_source._kafka_options.topic = "new_t"
-    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.STARTING)
+    job = SimpleStreamingIngestionJob(
+        "", "default", feature_table, SparkJobStatus.STARTING
+    )
 
     spark_client.feature_store.list_feature_tables.return_value = [new_ft]
     spark_client.list_jobs.return_value = [job]
@@ -143,15 +151,15 @@ def test_not_cancelling_starting_job(spark_client, feature_table):
     ensure_stream_ingestion_jobs(spark_client, all_projects=True)
 
     assert job.get_status() == SparkJobStatus.STARTING
-    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
-        new_ft, [], project="default"
-    )
+    assert spark_client.start_stream_to_online_ingestion.call_count == 2
 
 
 def test_not_retrying_failed_job(spark_client, feature_table):
     """ Job has failed on previous try """
 
-    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.FAILED)
+    job = SimpleStreamingIngestionJob(
+        "", "default", feature_table, SparkJobStatus.FAILED
+    )
 
     spark_client.feature_store.list_feature_tables.return_value = [feature_table]
     spark_client.list_jobs.return_value = [job]
@@ -160,21 +168,23 @@ def test_not_retrying_failed_job(spark_client, feature_table):
 
     spark_client.list_jobs.assert_called_once_with(include_terminated=True)
     assert job.get_status() == SparkJobStatus.FAILED
-    spark_client.start_stream_to_online_ingestion.assert_not_called()
+    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
+        feature_table, [], project="ride"
+    )
 
 
 def test_restarting_completed_job(spark_client, feature_table):
     """ Job has succesfully finished on previous try """
-    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.COMPLETED)
+    job = SimpleStreamingIngestionJob(
+        "", "default", feature_table, SparkJobStatus.COMPLETED
+    )
 
     spark_client.feature_store.list_feature_tables.return_value = [feature_table]
     spark_client.list_jobs.return_value = [job]
 
     ensure_stream_ingestion_jobs(spark_client, all_projects=True)
 
-    spark_client.start_stream_to_online_ingestion.assert_called_once_with(
-        feature_table, [], project="default"
-    )
+    assert spark_client.start_stream_to_online_ingestion.call_count == 2
 
 
 def test_stopping_running_job(spark_client, feature_table):
@@ -182,7 +192,9 @@ def test_stopping_running_job(spark_client, feature_table):
     new_ft = copy.deepcopy(feature_table)
     new_ft.stream_source = None
 
-    job = SimpleStreamingIngestionJob("", feature_table, SparkJobStatus.IN_PROGRESS)
+    job = SimpleStreamingIngestionJob(
+        "", "default", feature_table, SparkJobStatus.IN_PROGRESS
+    )
 
     spark_client.feature_store.list_feature_tables.return_value = [new_ft]
     spark_client.list_jobs.return_value = [job]

--- a/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
@@ -30,6 +30,7 @@ class SparkSpec extends UnitSpec with BeforeAndAfter {
     val sparkConf = new SparkConf()
       .setMaster("local[4]")
       .setAppName("Testing")
+      .set("spark.driver.bindAddress", "localhost")
       .set("spark.default.parallelism", "8")
       .set(
         "spark.metrics.conf.*.sink.statsd.class",


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR introduces ability to configure different Feast projects to run on different JobServices. This would allow different projects which may have different requirements to use a different storage (BigTable, Cassandra or Redis). If setting is not specified, by default, all projects are whitelisted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
JobService can now whitelist only certain Feast projects.
```
