### PR TITLE
Support for Schedule Spark Application

### DIFF
--- a/infra/scripts/helm/k8s-jobservice.tpl.yaml
+++ b/infra/scripts/helm/k8s-jobservice.tpl.yaml
@@ -1,4 +1,6 @@
 feast-jobservice:
+  image:
+    tag: ${IMAGE_TAG}
   envOverrides:
     FEAST_CORE_URL: feast-release-feast-core:6565
     FEAST_SPARK_LAUNCHER: k8s

--- a/infra/scripts/test-end-to-end-aws.sh
+++ b/infra/scripts/test-end-to-end-aws.sh
@@ -18,4 +18,4 @@ PYTHONPATH=sdk/python pytest tests/e2e/ \
       --redis-url $NODE_IP:32379 \
       --emr-region us-west-2 \
       --kafka-brokers $NODE_IP:30092 \
-      -m "not bq"
+      -m "not bq and not k8s"

--- a/infra/scripts/test-end-to-end-gcp.sh
+++ b/infra/scripts/test-end-to-end-gcp.sh
@@ -64,7 +64,7 @@ CMD=$(printf '%s' \
   "--core-url feast-release-feast-core:6565 " \
   "--serving-url feast-release-feast-online-serving:6566 " \
   "--job-service-url js-feast-jobservice:6568 " \
-  "--kafka-brokers 10.128.0.103:9094 --bq-project kf-feast --feast-version dev")
+  "--kafka-brokers 10.128.0.103:9094 --bq-project kf-feast --feast-version dev -m not k8s")
 
 # Delete old test running pod if it exists
 kubectl delete pod -n "$NAMESPACE" ci-test-runner 2>/dev/null || true

--- a/infra/scripts/test-end-to-end-gcp.sh
+++ b/infra/scripts/test-end-to-end-gcp.sh
@@ -64,7 +64,7 @@ CMD=$(printf '%s' \
   "--core-url feast-release-feast-core:6565 " \
   "--serving-url feast-release-feast-online-serving:6566 " \
   "--job-service-url js-feast-jobservice:6568 " \
-  "--kafka-brokers 10.128.0.103:9094 --bq-project kf-feast --feast-version dev -m not k8s")
+  "--kafka-brokers 10.128.0.103:9094 --bq-project kf-feast --feast-version dev -m \"not k8s\"")
 
 # Delete old test running pod if it exists
 kubectl delete pod -n "$NAMESPACE" ci-test-runner 2>/dev/null || true

--- a/infra/scripts/test-end-to-end-local.sh
+++ b/infra/scripts/test-end-to-end-local.sh
@@ -66,4 +66,4 @@ PYTHONPATH=sdk/python pytest tests/e2e/ \
       --staging-path s3a://feast-staging \
       --redis-url sparkop-redis-master.sparkop.svc.cluster.local:6379 \
       --kafka-brokers sparkop-kafka.sparkop.svc.cluster.local:9092 \
-      -m "not bq"
+      -m "not bq and not k8s"

--- a/infra/scripts/test-end-to-end-sparkop.sh
+++ b/infra/scripts/test-end-to-end-sparkop.sh
@@ -54,6 +54,7 @@ CMD=$(printf '%s' \
   "--core-url feast-release-feast-core:6565 " \
   "--serving-url feast-release-feast-online-serving:6566 " \
   "--job-service-url js-feast-jobservice:6568 " \
+  "--k8s-namespace sparkop-e2e " \
   "--kafka-brokers feast-release-kafka-headless:9092 --bq-project kf-feast --feast-version dev")
 
 # Delete old test running pod if it exists

--- a/protos/feast_spark/api/JobService.proto
+++ b/protos/feast_spark/api/JobService.proto
@@ -147,23 +147,11 @@ message ScheduleOfflineToOnlineIngestionJobRequest {
 
 }
 
-message ScheduleOfflineToOnlineIngestionJobResponse {
-  // Job ID assigned by Feast
-  string id = 1;
-
-  // Job start time
-  google.protobuf.Timestamp job_start_time = 2;
-
-  // Feature table associated with the job
-  string table_name = 3;
-
-  // Path to Spark job logs, if available
-  string log_uri = 4;
-}
+message ScheduleOfflineToOnlineIngestionJobResponse {}
 
 message UnscheduleOfflineToOnlineIngestionJobRequest {
   string project = 1;
-  string feature_table = 2;
+  string table_name = 2;
 }
 
 message UnscheduleOfflineToOnlineIngestionJobResponse {}

--- a/protos/feast_spark/api/JobService.proto
+++ b/protos/feast_spark/api/JobService.proto
@@ -29,6 +29,12 @@ service JobService {
     // Start job to ingest data from offline store into online store
     rpc StartOfflineToOnlineIngestionJob (StartOfflineToOnlineIngestionJobRequest) returns (StartOfflineToOnlineIngestionJobResponse);
 
+    // Start scheduled job to ingest data from offline store into online store
+    rpc ScheduleOfflineToOnlineIngestionJob (ScheduleOfflineToOnlineIngestionJobRequest) returns (ScheduleOfflineToOnlineIngestionJobResponse);
+
+    // Unschedule job to ingest data from offline store into online store
+    rpc UnscheduleOfflineToOnlineIngestionJob(UnscheduleOfflineToOnlineIngestionJobRequest) returns (UnscheduleOfflineToOnlineIngestionJobResponse);
+
     // Produce a training dataset, return a job id that will provide a file reference
     rpc GetHistoricalFeatures (GetHistoricalFeaturesRequest) returns (GetHistoricalFeaturesResponse);
 
@@ -126,6 +132,41 @@ message StartOfflineToOnlineIngestionJobResponse {
   // Path to Spark job logs, if available
   string log_uri = 4;
 }
+
+message ScheduleOfflineToOnlineIngestionJobRequest {
+    // Feature table to ingest
+    string project = 1;
+    string table_name = 2;
+
+
+    // Timespan of the ingested data per job, in days. The data from  end of the day - timespan till end of the day will be ingested. Eg. if the job execution date is 10/4/2021, and ingestion timespan is 2, then data from 9/4/2021 00:00 to 10/4/2021 23:59 (inclusive) will be ingested.
+    int32 ingestion_timespan = 3;
+
+   // Crontab string. Eg. 0 13 * * *
+    string cron_schedule = 4;
+
+}
+
+message ScheduleOfflineToOnlineIngestionJobResponse {
+  // Job ID assigned by Feast
+  string id = 1;
+
+  // Job start time
+  google.protobuf.Timestamp job_start_time = 2;
+
+  // Feature table associated with the job
+  string table_name = 3;
+
+  // Path to Spark job logs, if available
+  string log_uri = 4;
+}
+
+message UnscheduleOfflineToOnlineIngestionJobRequest {
+  string project = 1;
+  string feature_table = 2;
+}
+
+message UnscheduleOfflineToOnlineIngestionJobResponse {}
 
 message GetHistoricalFeaturesRequest {
   // List of feature references that are being retrieved

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -348,17 +348,19 @@ class Client:
             self._job_service.ScheduleOfflineToOnlineIngestionJob(request)
 
     def unschedule_offline_to_online_ingestion(
-        self, feature_table: feast.FeatureTable,
+        self, feature_table: feast.FeatureTable, project=None
     ):
+        feature_table_project = self._feast.project if project is None else project
+
         if not self._use_job_service:
             unschedule_offline_to_online_ingestion(
                 client=self,
-                project=self._feast.project,
+                project=feature_table_project,
                 feature_table=feature_table.name,
             )
         else:
             request = UnscheduleOfflineToOnlineIngestionJobRequest(
-                project=self._feast.project, table_name=feature_table.name,
+                project=feature_table_project, table_name=feature_table.name,
             )
 
             self._job_service.UnscheduleOfflineToOnlineIngestionJob(request)

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -348,11 +348,13 @@ class Client:
             self._job_service.ScheduleOfflineToOnlineIngestionJob(request)
 
     def unschedule_offline_to_online_ingestion(
-        self, feature_table: feast.FeatureTable, project: str = None,
+        self, feature_table: feast.FeatureTable,
     ):
         if not self._use_job_service:
             unschedule_offline_to_online_ingestion(
-                client=self, project=self._feast.project, feature_table=feature_table,
+                client=self,
+                project=self._feast.project,
+                feature_table=feature_table.name,
             )
         else:
             request = UnscheduleOfflineToOnlineIngestionJobRequest(

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -28,10 +28,14 @@ from feast_spark.api.JobService_pb2 import (
     JobStatus,
     JobType,
     ListJobsResponse,
+    ScheduleOfflineToOnlineIngestionJobRequest,
+    ScheduleOfflineToOnlineIngestionJobResponse,
     StartOfflineToOnlineIngestionJobRequest,
     StartOfflineToOnlineIngestionJobResponse,
     StartStreamToOnlineIngestionJobRequest,
     StartStreamToOnlineIngestionJobResponse,
+    UnscheduleOfflineToOnlineIngestionJobRequest,
+    UnscheduleOfflineToOnlineIngestionJobResponse,
 )
 from feast_spark.constants import ConfigOptions as opt
 from feast_spark.pyspark.abc import (
@@ -45,6 +49,7 @@ from feast_spark.pyspark.launcher import (
     get_job_by_id,
     get_stream_to_online_ingestion_params,
     list_jobs,
+    schedule_offline_to_online_ingestion,
     start_historical_feature_retrieval_job,
     start_offline_to_online_ingestion,
     start_stream_to_online_ingestion,
@@ -141,6 +146,36 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             table_name=request.table_name,
             log_uri=job.get_log_uri(),  # type: ignore
         )
+
+    def ScheduleOfflineToOnlineIngestionJob(
+        self, request: ScheduleOfflineToOnlineIngestionJobRequest, context
+    ):
+        """Schedule job to ingest data from offline store into online store periodically"""
+        feature_table = self.client.feature_store.get_feature_table(
+            request.table_name, request.project
+        )
+        job = schedule_offline_to_online_ingestion(
+            client=self.client,
+            project=request.project,
+            feature_table=feature_table,
+            ingestion_timespan=request.ingestion_timespan,
+            cron_schedule=request.cron_schedule,
+        )
+
+        job_start_timestamp = Timestamp()
+        job_start_timestamp.FromDatetime(job.get_start_time())
+
+        return ScheduleOfflineToOnlineIngestionJobResponse(
+            id=job.get_id(),
+            job_start_time=job_start_timestamp,
+            table_name=request.table_name,
+            log_uri=job.get_log_uri(),  # type: ignore
+        )
+
+    def UnscheduleOfflineToOnlineIngestionJob(
+        self, request: UnscheduleOfflineToOnlineIngestionJobRequest, context
+    ):
+        return UnscheduleOfflineToOnlineIngestionJobResponse()
 
     def GetHistoricalFeatures(self, request: GetHistoricalFeaturesRequest, context):
         """Produce a training dataset, return a job id that will provide a file reference"""

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -627,24 +627,6 @@ class BatchIngestionJob(SparkJob):
         raise NotImplementedError
 
 
-class ScheduledBatchIngestionJob(SparkJob):
-    """
-    Container for the ingestion job result
-    """
-
-    @abc.abstractmethod
-    def get_feature_table(self) -> str:
-        """
-        Get the feature table name associated with this job. Return empty string if unable to
-        determine the feature table, such as when the job is created by the earlier
-        version of Feast.
-
-        Returns:
-            str: Feature table name
-        """
-        raise NotImplementedError
-
-
 class StreamIngestionJob(SparkJob):
     """
     Container for the streaming ingestion job result
@@ -714,7 +696,7 @@ class JobLauncher(abc.ABC):
     @abc.abstractmethod
     def schedule_offline_to_online_ingestion(
         self, ingestion_job_params: ScheduledBatchIngestionJobParameters
-    ) -> ScheduledBatchIngestionJob:
+    ):
         """
         Submits a scheduled batch ingestion job to a Spark cluster.
 
@@ -724,6 +706,13 @@ class JobLauncher(abc.ABC):
 
         Returns:
             ScheduledBatchIngestionJob: wrapper around remote job that can be used to check when job completed.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def unschedule_offline_to_online_ingestion(self, project: str, feature_table: str):
+        """
+        Unschedule a scheduled batch ingestion job.
         """
         raise NotImplementedError
 

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -535,8 +535,6 @@ class ScheduledBatchIngestionJobParameters(IngestionJobParameters):
             "offline",
             "--ingestion-timespan",
             str(self._ingestion_timespan),
-            "--cron-schedule",
-            self._cron_schedule,
         ]
 
 

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -339,7 +339,7 @@ def unschedule_offline_to_online_ingestion(
 ):
 
     launcher = resolve_launcher(client.config)
-    launcher.unschedule_offline_to_online_ingestion(project, feature_table)
+    launcher.unschedule_offline_to_online_ingestion(project, feature_table.name)
 
 
 def get_stream_to_online_ingestion_params(

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -18,7 +18,6 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
-    ScheduledBatchIngestionJob,
     ScheduledBatchIngestionJobParameters,
     SparkJob,
     StreamIngestionJob,
@@ -301,11 +300,11 @@ def schedule_offline_to_online_ingestion(
     feature_table: FeatureTable,
     ingestion_timespan: int,
     cron_schedule: str,
-) -> ScheduledBatchIngestionJob:
+):
 
     launcher = resolve_launcher(client.config)
 
-    return launcher.schedule_offline_to_online_ingestion(
+    launcher.schedule_offline_to_online_ingestion(
         ScheduledBatchIngestionJobParameters(
             jar=client.config.get(opt.SPARK_INGESTION_JAR),
             source=_source_to_argument(feature_table.batch_source, client.config),
@@ -333,6 +332,14 @@ def schedule_offline_to_online_ingestion(
             stencil_url=client.config.get(opt.STENCIL_URL),
         )
     )
+
+
+def unschedule_offline_to_online_ingestion(
+    client: "Client", project: str, feature_table: FeatureTable,
+):
+
+    launcher = resolve_launcher(client.config)
+    launcher.unschedule_offline_to_online_ingestion(project, feature_table)
 
 
 def get_stream_to_online_ingestion_params(

--- a/python/feast_spark/pyspark/launchers/aws/emr.py
+++ b/python/feast_spark/pyspark/launchers/aws/emr.py
@@ -14,7 +14,6 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
-    ScheduledBatchIngestionJob,
     ScheduledBatchIngestionJobParameters,
     SparkJob,
     SparkJobFailure,
@@ -302,9 +301,14 @@ class EmrClusterLauncher(JobLauncher):
 
     def schedule_offline_to_online_ingestion(
         self, ingestion_job_params: ScheduledBatchIngestionJobParameters
-    ) -> ScheduledBatchIngestionJob:
+    ):
         raise NotImplementedError(
             "Schedule spark jobs are not supported by emr launcher"
+        )
+
+    def unschedule_offline_to_online_ingestion(self, project: str, feature_table: str):
+        raise NotImplementedError(
+            "Unschedule spark jobs are not supported by emr launcher"
         )
 
     def start_stream_to_online_ingestion(

--- a/python/feast_spark/pyspark/launchers/aws/emr.py
+++ b/python/feast_spark/pyspark/launchers/aws/emr.py
@@ -14,6 +14,8 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
+    ScheduledBatchIngestionJob,
+    ScheduledBatchIngestionJobParameters,
     SparkJob,
     SparkJobFailure,
     SparkJobStatus,
@@ -296,6 +298,13 @@ class EmrClusterLauncher(JobLauncher):
             job_ref,
             ingestion_job_params.get_project(),
             ingestion_job_params.get_feature_table_name(),
+        )
+
+    def schedule_offline_to_online_ingestion(
+        self, ingestion_job_params: ScheduledBatchIngestionJobParameters
+    ) -> ScheduledBatchIngestionJob:
+        raise NotImplementedError(
+            "Schedule spark jobs are not supported by emr launcher"
         )
 
     def start_stream_to_online_ingestion(

--- a/python/feast_spark/pyspark/launchers/gcloud/dataproc.py
+++ b/python/feast_spark/pyspark/launchers/gcloud/dataproc.py
@@ -14,6 +14,8 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
+    ScheduledBatchIngestionJob,
+    ScheduledBatchIngestionJobParameters,
     SparkJob,
     SparkJobFailure,
     SparkJobParameters,
@@ -418,6 +420,13 @@ class DataprocClusterLauncher(JobLauncher):
             cancel_fn=cancel_fn,
             project=self.project_id,
             region=self.region,
+        )
+
+    def schedule_offline_to_online_ingestion(
+        self, ingestion_job_params: ScheduledBatchIngestionJobParameters
+    ) -> ScheduledBatchIngestionJob:
+        raise NotImplementedError(
+            "Schedule spark jobs are not supported by dataproc launcher"
         )
 
     def start_stream_to_online_ingestion(

--- a/python/feast_spark/pyspark/launchers/gcloud/dataproc.py
+++ b/python/feast_spark/pyspark/launchers/gcloud/dataproc.py
@@ -14,7 +14,6 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
-    ScheduledBatchIngestionJob,
     ScheduledBatchIngestionJobParameters,
     SparkJob,
     SparkJobFailure,
@@ -424,9 +423,14 @@ class DataprocClusterLauncher(JobLauncher):
 
     def schedule_offline_to_online_ingestion(
         self, ingestion_job_params: ScheduledBatchIngestionJobParameters
-    ) -> ScheduledBatchIngestionJob:
+    ):
         raise NotImplementedError(
             "Schedule spark jobs are not supported by dataproc launcher"
+        )
+
+    def unschedule_offline_to_online_ingestion(self, project: str, feature_table: str):
+        raise NotImplementedError(
+            "Unschedule spark jobs are not supported by dataproc launcher"
         )
 
     def start_stream_to_online_ingestion(

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -63,7 +63,13 @@ def _generate_job_id() -> str:
 
 
 def _generate_scheduled_job_id(project: str, feature_table_name: str) -> str:
-    return f"feast-{project}-{feature_table_name}".replace("_", "-")
+    scheduled_job_id = f"feast-{project}-{feature_table_name}".replace("_", "-")
+    k8s_res_name_char_limit = 253
+    return (
+        scheduled_job_id
+        if len(scheduled_job_id) <= k8s_res_name_char_limit
+        else scheduled_job_id[:k8s_res_name_char_limit]
+    )
 
 
 def _truncate_label(label: str) -> str:

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -63,7 +63,7 @@ def _generate_job_id() -> str:
 
 
 def _generate_scheduled_job_id(project: str, feature_table_name: str) -> str:
-    return f"feast-{project}-{feature_table_name}"
+    return f"feast-{project}-{feature_table_name}".replace("_", "-")
 
 
 def _truncate_label(label: str) -> str:
@@ -410,7 +410,10 @@ class KubernetesJobLauncher(JobLauncher):
         )
 
         _submit_scheduled_job(
-            api=self._api, resource=resource, namespace=self._namespace,
+            api=self._api,
+            name=schedule_job_id,
+            resource=resource,
+            namespace=self._namespace,
         )
 
     def unschedule_offline_to_online_ingestion(self, project: str, feature_table: str):

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -65,6 +65,7 @@ def _generate_job_id() -> str:
 def _generate_scheduled_job_id(project: str, feature_table_name: str) -> str:
     scheduled_job_id = f"feast-{project}-{feature_table_name}".replace("_", "-")
     k8s_res_name_char_limit = 253
+
     return (
         scheduled_job_id
         if len(scheduled_job_id) <= k8s_res_name_char_limit

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -171,7 +171,7 @@ def _prepare_scheduled_job_resource(
     """ Prepare ScheduledSparkApplication custom resource configs """
     scheduled_job = deepcopy(scheduled_job_template)
 
-    labels = {LABEL_JOBID: scheduled_job_id, LABEL_JOBTYPE: job_type}
+    labels = {LABEL_JOBTYPE: job_type}
     if extra_labels:
         labels = {**labels, **extra_labels}
 

--- a/python/feast_spark/pyspark/launchers/standalone/local.py
+++ b/python/feast_spark/pyspark/launchers/standalone/local.py
@@ -17,6 +17,8 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
+    ScheduledBatchIngestionJob,
+    ScheduledBatchIngestionJobParameters,
     SparkJob,
     SparkJobFailure,
     SparkJobParameters,
@@ -335,6 +337,13 @@ class StandaloneClusterLauncher(JobLauncher):
         )
         global_job_cache.add_job(job)
         return job
+
+    def schedule_offline_to_online_ingestion(
+        self, ingestion_job_params: ScheduledBatchIngestionJobParameters
+    ) -> ScheduledBatchIngestionJob:
+        raise NotImplementedError(
+            "Schedule spark jobs are not supported by standalone launcher"
+        )
 
     def start_stream_to_online_ingestion(
         self, ingestion_job_params: StreamIngestionJobParameters

--- a/python/feast_spark/pyspark/launchers/standalone/local.py
+++ b/python/feast_spark/pyspark/launchers/standalone/local.py
@@ -17,7 +17,6 @@ from feast_spark.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
-    ScheduledBatchIngestionJob,
     ScheduledBatchIngestionJobParameters,
     SparkJob,
     SparkJobFailure,
@@ -340,9 +339,14 @@ class StandaloneClusterLauncher(JobLauncher):
 
     def schedule_offline_to_online_ingestion(
         self, ingestion_job_params: ScheduledBatchIngestionJobParameters
-    ) -> ScheduledBatchIngestionJob:
+    ):
         raise NotImplementedError(
             "Schedule spark jobs are not supported by standalone launcher"
+        )
+
+    def unschedule_offline_to_online_ingestion(self, project: str, feature_table: str):
+        raise NotImplementedError(
+            "Unschedule spark jobs are not supported by standalone launcher"
         )
 
     def start_stream_to_online_ingestion(

--- a/python/feast_spark/remote_job.py
+++ b/python/feast_spark/remote_job.py
@@ -9,6 +9,7 @@ from feast.core.JobService_pb2_grpc import JobServiceStub
 from feast_spark.pyspark.abc import (
     BatchIngestionJob,
     RetrievalJob,
+    ScheduledBatchIngestionJob,
     SparkJob,
     SparkJobFailure,
     SparkJobStatus,
@@ -123,6 +124,29 @@ class RemoteRetrievalJob(RemoteJobMixin, RetrievalJob):
 class RemoteBatchIngestionJob(RemoteJobMixin, BatchIngestionJob):
     """
     Batch ingestion job result.
+    """
+
+    def __init__(
+        self,
+        service: JobServiceStub,
+        grpc_extra_param_provider: GrpcExtraParamProvider,
+        job_id: str,
+        feature_table: str,
+        start_time: datetime,
+        log_uri: Optional[str],
+    ):
+        super().__init__(
+            service, grpc_extra_param_provider, job_id, start_time, log_uri
+        )
+        self._feature_table = feature_table
+
+    def get_feature_table(self) -> str:
+        return self._feature_table
+
+
+class RemoteScheduledBatchIngestionJob(RemoteJobMixin, ScheduledBatchIngestionJob):
+    """
+    Scheduled batch ingestion job result.
     """
 
     def __init__(

--- a/python/feast_spark/remote_job.py
+++ b/python/feast_spark/remote_job.py
@@ -9,7 +9,6 @@ from feast.core.JobService_pb2_grpc import JobServiceStub
 from feast_spark.pyspark.abc import (
     BatchIngestionJob,
     RetrievalJob,
-    ScheduledBatchIngestionJob,
     SparkJob,
     SparkJobFailure,
     SparkJobStatus,
@@ -124,29 +123,6 @@ class RemoteRetrievalJob(RemoteJobMixin, RetrievalJob):
 class RemoteBatchIngestionJob(RemoteJobMixin, BatchIngestionJob):
     """
     Batch ingestion job result.
-    """
-
-    def __init__(
-        self,
-        service: JobServiceStub,
-        grpc_extra_param_provider: GrpcExtraParamProvider,
-        job_id: str,
-        feature_table: str,
-        start_time: datetime,
-        log_uri: Optional[str],
-    ):
-        super().__init__(
-            service, grpc_extra_param_provider, job_id, start_time, log_uri
-        )
-        self._feature_table = feature_table
-
-    def get_feature_table(self) -> str:
-        return self._feature_table
-
-
-class RemoteScheduledBatchIngestionJob(RemoteJobMixin, ScheduledBatchIngestionJob):
-    """
-    Scheduled batch ingestion job result.
     """
 
     def __init__(

--- a/python/setup.py
+++ b/python/setup.py
@@ -50,7 +50,8 @@ REQUIRED = [
     "google-cloud-dataproc==2.0.2",
     "kubernetes==12.0.*",
     "grpcio-tools==1.31.0",
-    "mypy-protobuf"
+    "mypy-protobuf",
+    "croniter==1.*",
 ]
 
 # README file from Feast repo root directory

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -17,10 +17,10 @@
 package feast.ingestion
 
 import feast.ingestion.utils.JsonUtils
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s._
-import org.json4s.jackson.JsonMethods.{parse => parseJSON}
 import org.json4s.ext.JavaEnumNameSerializer
+import org.json4s.jackson.JsonMethods.{parse => parseJSON}
 
 object IngestionJob {
   import Modes._
@@ -77,6 +77,15 @@ object IngestionJob {
     opt[String](name = "end")
       .action((x, c) => c.copy(endTime = DateTime.parse(x)))
       .text("End timestamp for offline ingestion")
+
+    opt[String](name = "ingestion_timespan")
+      .action((x, c) => {
+        val currentTimeUTC = new DateTime(DateTimeZone.UTC);
+        val startTime      = currentTimeUTC.withTimeAtStartOfDay().minusDays(x.toInt - 1)
+        val endTime        = currentTimeUTC.withTimeAtStartOfDay().plusDays(1)
+        c.copy(startTime = startTime, endTime = endTime)
+      })
+      .text("Ingestion timespan")
 
     opt[String](name = "redis")
       .action((x, c) => c.copy(store = parseJSON(x).extract[RedisConfig]))

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -78,7 +78,7 @@ object IngestionJob {
       .action((x, c) => c.copy(endTime = DateTime.parse(x)))
       .text("End timestamp for offline ingestion")
 
-    opt[String](name = "ingestion_timespan")
+    opt[String](name = "ingestion-timespan")
       .action((x, c) => {
         val currentTimeUTC = new DateTime(DateTimeZone.UTC);
         val startTime      = currentTimeUTC.withTimeAtStartOfDay().minusDays(x.toInt - 1)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,6 +22,7 @@ def pytest_addoption(parser):
     parser.addoption("--dataproc-executor-instances", action="store", default="2")
     parser.addoption("--dataproc-executor-cores", action="store", default="2")
     parser.addoption("--dataproc-executor-memory", action="store", default="2g")
+    parser.addoption("--k8s-namespace", action="store", default="sparkop-e2e")
     parser.addoption("--ingestion-jar", action="store")
     parser.addoption("--redis-url", action="store", default="localhost:6379")
     parser.addoption("--redis-cluster", action="store_true")

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest as pytest
+from kubernetes import client, config
 
 from feast import Client, Entity, Feature, FeatureTable, FileSource, ValueType
 from feast.data_format import ParquetFormat
@@ -30,6 +31,15 @@ def test_schedule_batch_ingestion_jobs(
 
     feast_spark_client.schedule_offline_to_online_ingestion(
         feature_table, 1, "0 0 * * *"
+    )
+    config.load_incluster_config()
+    k8s_api = client.CustomObjectsApi()
+    k8s_api.get_namespaced_custom_object(
+        group="sparkoperator.k8s.io",
+        version="v1beta2",
+        namespace="default",
+        plural="scheduledsparkapplications",
+        name=f"feast-{feast_client.project}-{feature_table.name}".replace("_", "-"),
     )
     feast_spark_client.unschedule_offline_to_online_ingestion(
         feature_table, feast_spark_client._feast.project

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -1,13 +1,15 @@
+import uuid
+
 import pytest as pytest
 
-from feast import Entity, Feature, FeatureTable, FileSource, ValueType
+from feast import Client, Entity, Feature, FeatureTable, FileSource, ValueType
 from feast.data_format import ParquetFormat
 from feast_spark import Client as SparkClient
 
 
 @pytest.mark.env("k8s")
 def test_schedule_batch_ingestion_jobs(
-    pytestconfig, feast_spark_client: SparkClient
+    pytestconfig, feast_client: Client, feast_spark_client: SparkClient
 ):
     entity = Entity(name="s2id", description="S2id", value_type=ValueType.INT64,)
     batch_source = FileSource(
@@ -18,11 +20,17 @@ def test_schedule_batch_ingestion_jobs(
         date_partition_column="datetime",
     )
     feature_table = FeatureTable(
-        name="drivers",
+        name=f"schedule_{str(uuid.uuid4())}",
         entities=["s2id"],
         features=[Feature("unique_drivers", ValueType.INT64)],
         batch_source=batch_source,
     )
+    feast_client.apply(entity)
+    feast_client.apply(feature_table)
 
-    feast_spark_client.schedule_offline_to_online_ingestion(feature_table, 1, "0 0 * * *")
-    feast_spark_client.unschedule_offline_to_online_ingestion(feature_table, feast_spark_client._feast.project)
+    feast_spark_client.schedule_offline_to_online_ingestion(
+        feature_table, 1, "0 0 * * *"
+    )
+    feast_spark_client.unschedule_offline_to_online_ingestion(
+        feature_table, feast_spark_client._feast.project
+    )

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -37,7 +37,7 @@ def test_schedule_batch_ingestion_jobs(
     k8s_api.get_namespaced_custom_object(
         group="sparkoperator.k8s.io",
         version="v1beta2",
-        namespace="default",
+        namespace=pytestconfig.getoption("k8s_namespace"),
         plural="scheduledsparkapplications",
         name=f"feast-{feast_client.project}-{feature_table.name}".replace("_", "-"),
     )

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -41,6 +41,4 @@ def test_schedule_batch_ingestion_jobs(
         plural="scheduledsparkapplications",
         name=f"feast-{feast_client.project}-{feature_table.name}".replace("_", "-"),
     )
-    feast_spark_client.unschedule_offline_to_online_ingestion(
-        feature_table, feast_spark_client._feast.project
-    )
+    feast_spark_client.unschedule_offline_to_online_ingestion(feature_table)

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -20,7 +20,7 @@ def test_schedule_batch_ingestion_jobs(
         date_partition_column="datetime",
     )
     feature_table = FeatureTable(
-        name=f"schedule_{str(uuid.uuid4())}",
+        name=f"schedule_{str(uuid.uuid4())}".replace("-", "_"),
         entities=["s2id"],
         features=[Feature("unique_drivers", ValueType.INT64)],
         batch_source=batch_source,

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -1,0 +1,28 @@
+import pytest as pytest
+
+from feast import Entity, Feature, FeatureTable, FileSource, ValueType
+from feast.data_format import ParquetFormat
+from feast_spark import Client as SparkClient
+
+
+@pytest.mark.env("k8s")
+def test_schedule_batch_ingestion_jobs(
+    pytestconfig, feast_spark_client: SparkClient
+):
+    entity = Entity(name="s2id", description="S2id", value_type=ValueType.INT64,)
+    batch_source = FileSource(
+        file_format=ParquetFormat(),
+        file_url="gs://example/feast/*",
+        event_timestamp_column="datetime_col",
+        created_timestamp_column="timestamp",
+        date_partition_column="datetime",
+    )
+    feature_table = FeatureTable(
+        name="drivers",
+        entities=["s2id"],
+        features=[Feature("unique_drivers", ValueType.INT64)],
+        batch_source=batch_source,
+    )
+
+    feast_spark_client.schedule_offline_to_online_ingestion(feature_table, 1, "0 0 * * *")
+    feast_spark_client.unschedule_offline_to_online_ingestion(feature_table, feast_spark_client._feast.project)


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

Spark operator support scheduling spark application via the custom resource ScheduledSparkApplication. This PR allows the user to schedule batch ingestion jobs, either via the client directly, or via job service.

Support for scheduling spark application for non k8s launchers are out of scope.

```release-note
Users of k8s launcher can now schedule batch ingestion jobs via ScheduledSparkApplication.
```
