### PR TITLE
Migrate sparkop e2e tests to kf-feast cluster

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -66,9 +66,11 @@ presubmits:
   always_run: true
   max_concurrency: 1
   spec:
+    metadata:
+      namespace: sparkop-e2e
     containers:
       - image: gcr.io/kf-feast/feast-ci:latest
-        command: [ "infra/scripts/aws-runner.sh", "--location-from-prow", "--project-name", "feast-ci-sparkop-project" ]
+        command: [ "infra/scripts/test-end-to-end-sparkop.sh"]
         resources:
           requests:
             cpu: "2"
@@ -78,18 +80,6 @@ presubmits:
             value: /etc/gcloud/service-account.json
           - name: DOCKER_REPOSITORY
             value: gcr.io/kf-feast
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: feast-aws-creds
-                key: AWS_ACCESS_KEY_ID
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: feast-aws-creds
-                key: AWS_SECRET_ACCESS_KEY
-          - name: AWS_DEFAULT_REGION
-            value: us-west-2
         volumeMounts:
           - mountPath: /etc/gcloud/service-account.json
             name: service-account
@@ -235,9 +225,11 @@ postsubmits:
   branches:
     - ^master$
   spec:
+    metadata:
+      namespace: sparkop-e2e
     containers:
       - image: gcr.io/kf-feast/feast-ci:latest
-        command: [ "infra/scripts/aws-runner.sh", "--location-from-prow", "--project-name", "feast-ci-sparkop-project" ]
+        command: [ "infra/scripts/test-end-to-end-sparkop.sh"]
         resources:
           requests:
             cpu: "2"
@@ -247,18 +239,6 @@ postsubmits:
             value: /etc/gcloud/service-account.json
           - name: DOCKER_REPOSITORY
             value: gcr.io/kf-feast
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: feast-aws-creds
-                key: AWS_ACCESS_KEY_ID
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: feast-aws-creds
-                key: AWS_SECRET_ACCESS_KEY
-          - name: AWS_DEFAULT_REGION
-            value: us-west-2
         volumeMounts:
           - mountPath: /etc/gcloud/service-account.json
             name: service-account

--- a/infra/scripts/helm/k8s-jobservice.tpl.yaml
+++ b/infra/scripts/helm/k8s-jobservice.tpl.yaml
@@ -1,0 +1,52 @@
+feast-jobservice:
+  envOverrides:
+    FEAST_CORE_URL: feast-release-feast-core:6565
+    FEAST_SPARK_LAUNCHER: k8s
+    FEAST_SPARK_K8S_NAMESPACE: sparkop-e2e
+    FEAST_SPARK_K8S_USE_INCLUSTER_CONFIG: True
+    FEAST_TELEMETRY: False
+    FEAST_SPARK_STAGING_LOCATION: gs://feast-templocation-kf-feast
+    FEAST_REDIS_HOST: feast-release-redis-master
+    FEAST_REDIS_PORT: 6379
+    FEAST_JOB_SERVICE_ENABLE_CONTROL_LOOP: False
+    FEAST_SPARK_INGESTION_JAR: local:///opt/spark/jars/feast-ingestion-spark-${IMAGE_TAG}.jar
+
+  sparkOperator:
+    enabled: true
+    jobTemplate:
+      apiVersion: "sparkoperator.k8s.io/v1beta2"
+      kind: SparkApplication
+      spec:
+        type: Scala
+        mode: cluster
+        image: "gcr.io/kf-feast/feast-spark:${IMAGE_TAG}"
+        hadoopConf:
+          "fs.gs.project.id": "kf-feast"
+          "google.cloud.auth.service.account.enable": "true"
+          "google.cloud.auth.service.account.json.keyfile": "/mnt/secrets/credentials.json"
+        sparkVersion: "3.0.1"
+        timeToLiveSeconds: 3600
+        pythonVersion: "3"
+        restartPolicy:
+          type: Never
+        driver:
+          cores: 1
+          coreLimit: "1200m"
+          memory: "512m"
+          labels:
+            version: 3.0.1
+          secrets:
+            - name: feast-gcp-service-account
+              path: /mnt/secrets
+              secretType: GCPServiceAccount
+        executor:
+          cores: 1
+          instances: 1
+          memory: "512m"
+          labels:
+            version: 3.0.1
+          secrets:
+            - name: feast-gcp-service-account
+              path: /mnt/secrets
+              secretType: GCPServiceAccount
+

--- a/infra/scripts/helm/k8s-jobservice.tpl.yaml
+++ b/infra/scripts/helm/k8s-jobservice.tpl.yaml
@@ -32,7 +32,7 @@ feast-jobservice:
         driver:
           cores: 1
           coreLimit: "1200m"
-          memory: "512m"
+          memory: "600m"
           labels:
             version: 3.0.1
           secrets:
@@ -42,7 +42,7 @@ feast-jobservice:
         executor:
           cores: 1
           instances: 1
-          memory: "512m"
+          memory: "800m"
           labels:
             version: 3.0.1
           secrets:

--- a/infra/scripts/helm/k8s-jobservice.tpl.yaml
+++ b/infra/scripts/helm/k8s-jobservice.tpl.yaml
@@ -35,6 +35,7 @@ feast-jobservice:
           memory: "600m"
           labels:
             version: 3.0.2
+          javaOptions: "-Dio.netty.tryReflectionSetAccessible=true"
           secrets:
             - name: feast-gcp-service-account
               path: /mnt/secrets
@@ -45,6 +46,7 @@ feast-jobservice:
           memory: "800m"
           labels:
             version: 3.0.2
+          javaOptions: "-Dio.netty.tryReflectionSetAccessible=true"
           secrets:
             - name: feast-gcp-service-account
               path: /mnt/secrets

--- a/infra/scripts/helm/k8s-jobservice.tpl.yaml
+++ b/infra/scripts/helm/k8s-jobservice.tpl.yaml
@@ -24,7 +24,7 @@ feast-jobservice:
           "fs.gs.project.id": "kf-feast"
           "google.cloud.auth.service.account.enable": "true"
           "google.cloud.auth.service.account.json.keyfile": "/mnt/secrets/credentials.json"
-        sparkVersion: "3.0.1"
+        sparkVersion: "3.0.2"
         timeToLiveSeconds: 3600
         pythonVersion: "3"
         restartPolicy:
@@ -34,7 +34,7 @@ feast-jobservice:
           coreLimit: "1200m"
           memory: "600m"
           labels:
-            version: 3.0.1
+            version: 3.0.2
           secrets:
             - name: feast-gcp-service-account
               path: /mnt/secrets
@@ -44,7 +44,7 @@ feast-jobservice:
           instances: 1
           memory: "800m"
           labels:
-            version: 3.0.1
+            version: 3.0.2
           secrets:
             - name: feast-gcp-service-account
               path: /mnt/secrets

--- a/infra/scripts/test-end-to-end-sparkop.sh
+++ b/infra/scripts/test-end-to-end-sparkop.sh
@@ -1,21 +1,54 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-pip install "s3fs" "aiobotocore==1.2.2" "boto3" "urllib3>=1.25.4"
+set -e
 
 export DISABLE_FEAST_SERVICE_FIXTURES=1
 export DISABLE_SERVICE_FIXTURES=1
-export FEAST_TELEMETRY="False"
+export GIT_TAG=${PULL_PULL_SHA:-${PULL_BASE_SHA}}
+export DOCKER_REPOSITORY=gcr.io/kf-feast
+export JOBSERVICE_HELM_VALUES=infra/scripts/helm/k8s-jobservice.yaml
 
-export FEAST_SPARK_K8S_NAMESPACE=sparkop
+test -z ${GCLOUD_PROJECT} && GCLOUD_PROJECT="kf-feast"
+test -z ${GCLOUD_REGION} && GCLOUD_REGION="us-central1"
+test -z ${GCLOUD_NETWORK} && GCLOUD_NETWORK="default"
+test -z ${GCLOUD_SUBNET} && GCLOUD_SUBNET="default"
+test -z ${KUBE_CLUSTER} && KUBE_CLUSTER="feast-e2e-dataflow"
 
-PYTHONPATH=sdk/python pytest tests/e2e/ \
-      --feast-version develop \
-      --core-url feast-release-feast-core:6565 \
-      --serving-url feast-release-feast-online-serving:6566 \
-      --env k8s \
-      --staging-path $STAGING_PATH \
-      --redis-url feast-release-redis-master.sparkop.svc.cluster.local:6379 \
-      --kafka-brokers feast-release-kafka.sparkop.svc.cluster.local:9092 \
-      -m "not bq"
+gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
+gcloud -q auth configure-docker
+
+gcloud config set project ${GCLOUD_PROJECT}
+gcloud config set compute/region ${GCLOUD_REGION}
+gcloud config list
+
+gcloud container clusters get-credentials ${KUBE_CLUSTER} --region ${GCLOUD_REGION} --project ${GCLOUD_PROJECT}
+
+source infra/scripts/k8s-common-functions.sh
+
+NAMESPACE="sparkop-e2e"
+
+k8s_cleanup "feast-release" "$NAMESPACE"
+k8s_cleanup "js" "$NAMESPACE"
+
+kubectl delete sparkapplication --all -n $NAMESPACE
+kubectl delete scheduledsparkapplication --all -n $NAMESPACE
+
+wait_for_image "${DOCKER_REPOSITORY}" feast-jobservice "${GIT_TAG}"
+wait_for_image "${DOCKER_REPOSITORY}" feast-spark "${GIT_TAG}"
+
+sed s/\$\{IMAGE_TAG\}/${JOBSERVICE_GIT_TAG:-$GIT_TAG}/g infra/scripts/helm/k8s-jobservice.tpl.yaml > $JOBSERVICE_HELM_VALUES
+
+helm_install "js" "${DOCKER_REPOSITORY}" "${GIT_TAG}" "$NAMESPACE" \
+  --set 'feast-online-serving.application-override\.yaml.feast.stores[0].type=REDIS' \
+  --set 'feast-online-serving.application-override\.yaml.feast.stores[0].name=online' \
+  --set 'feast-online-serving.application-override\.yaml.feast.stores[0].config.host=feast-release-redis-master' \
+  --set 'feast-online-serving.application-override\.yaml.feast.stores[0].config.port=6379' \
+
+make install-python
+python -m pip install -qr tests/requirements.txt
+pytest -v tests/e2e/ --env k8s \
+	--staging-path gs://feast-templocation-kf-feast/ \
+	--core-url feast-release-feast-core:6565 \
+  --serving-url feast-release-feast-online-serving:6566 \
+  --job-service-url js-feast-jobservice:6568 \
+  --kafka-brokers feast-release-kafka-headless:9092 --bq-project kf-feast --feast-version dev

--- a/tests/e2e/fixtures/client.py
+++ b/tests/e2e/fixtures/client.py
@@ -95,15 +95,12 @@ def feast_client(
         return Client(
             core_url=f"{feast_core[0]}:{feast_core[1]}",
             serving_url=f"{feast_serving[0]}:{feast_serving[1]}",
-            spark_launcher="k8s",
-            spark_staging_location=os.path.join(local_staging_path, "k8s"),
-            spark_ingestion_jar=ingestion_job_jar,
-            redis_host=pytestconfig.getoption("redis_url").split(":")[0],
-            redis_port=pytestconfig.getoption("redis_url").split(":")[1],
             historical_feature_output_location=os.path.join(
                 local_staging_path, "historical_output"
             ),
+            spark_staging_location=os.path.join(local_staging_path, "k8s"),
             enable_auth=pytestconfig.getoption("enable_auth"),
+            **job_service_env,
         )
     else:
         raise KeyError(f"Unknown environment {pytestconfig.getoption('env')}")
@@ -185,6 +182,7 @@ def tfrecord_feast_client(
             historical_feature_output_location=os.path.join(
                 local_staging_path, "historical_output"
             ),
+            **job_service_env,
         )
     else:
         raise KeyError(f"Unknown environment {pytestconfig.getoption('env')}")


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, the spark op e2e tests run on aws cluster, which not all maintainers have access to. This PR move the e2e tests to kf-feast project k8 cluster. At the same time, instead of using k8s launcher directly, the e2e test will make use of jobservice, so that more use cases are covered.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
