### PR TITLE
Configurable triggering interval from streaming ingestion

### DIFF
--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -160,6 +160,11 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Whitelisted Feast projects
     WHITELISTED_PROJECTS: Optional[str] = None
 
+    #: If set - streaming ingestion job will be consuming incoming rows not continuously,
+    #: but periodically with configured interval (in seconds).
+    #: That may help to control amount of write requests to storage
+    SPARK_STREAMING_TRIGGERING_INTERVAL: Optional[str] = None
+
     def defaults(self):
         return {
             k: getattr(self, k)

--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -503,6 +503,7 @@ class StreamIngestionJobParameters(IngestionJobParameters):
         checkpoint_path: Optional[str] = None,
         stencil_url: Optional[str] = None,
         drop_invalid_rows: bool = False,
+        triggering_interval: Optional[int] = None,
     ):
         super().__init__(
             feature_table,
@@ -523,6 +524,7 @@ class StreamIngestionJobParameters(IngestionJobParameters):
         )
         self._extra_jars = extra_jars
         self._checkpoint_path = checkpoint_path
+        self._triggering_interval = triggering_interval
 
     def get_name(self) -> str:
         return f"{self.get_job_type().to_pascal_case()}-{self.get_feature_table_name()}"
@@ -538,6 +540,8 @@ class StreamIngestionJobParameters(IngestionJobParameters):
         args.extend(["--mode", "online"])
         if self._checkpoint_path:
             args.extend(["--checkpoint-path", self._checkpoint_path])
+        if self._triggering_interval:
+            args.extend(["--triggering-interval", str(self._triggering_interval)])
         return args
 
     def get_job_hash(self) -> str:

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -315,6 +315,9 @@ def get_stream_to_online_ingestion_params(
         checkpoint_path=client.config.get(opt.CHECKPOINT_PATH),
         stencil_url=client.config.get(opt.STENCIL_URL),
         drop_invalid_rows=client.config.get(opt.INGESTION_DROP_INVALID_ROWS),
+        triggering_interval=client.config.getint(
+            opt.SPARK_STREAMING_TRIGGERING_INTERVAL, default=None
+        ),
     )
 
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -101,6 +101,9 @@ object IngestionJob {
 
     opt[String](name = "checkpoint-path")
       .action((x, c) => c.copy(checkpointPath = Some(x)))
+
+    opt[Int](name = "triggering-interval")
+      .action((x, c) => c.copy(streamingTriggeringSecs = x))
   }
 
   def main(args: Array[String]): Unit = {

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -16,6 +16,8 @@
  */
 package feast.ingestion.stores.bigtable
 
+import java.io.IOException
+
 import com.google.cloud.bigtable.hbase.BigtableConfiguration
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.{
@@ -75,7 +77,13 @@ class BigTableSinkRelation(
       try {
         admin.createTable(table)
       } catch {
-        case _: TableExistsException => admin.modifyTable(table)
+        case _: TableExistsException =>
+          try {
+            admin.modifyTable(table)
+          } catch {
+            case e: IOException =>
+              println(s"Table modification failed: ${e.getMessage}")
+          }
       }
     } finally {
       btConn.close()


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Some target storage may have limitations or quotas on amount of write requests per time period. To address that issue this PR makes write interval in StreamingPipeline configurable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
SPARK_STREAMING_TRIGGERING_INTERVAL - new configurable option
```
