### PR TITLE
Bump hadoop aws version to 3.2.0 for local launcher

### DIFF
--- a/python/feast_spark/pyspark/launchers/standalone/local.py
+++ b/python/feast_spark/pyspark/launchers/standalone/local.py
@@ -294,8 +294,8 @@ class StandaloneClusterLauncher(JobLauncher):
                 ",".join([BQ_SPARK_PACKAGE] + job_params.get_extra_packages()),
                 "--jars",
                 "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar,"
-                "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar,"
-                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar",
+                "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.0/hadoop-aws-3.2.0.jar,"
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.874/aws-java-sdk-bundle-1.11.874.jar",
                 "--conf",
                 "spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem",
                 "--conf",


### PR DESCRIPTION
Signed-off-by: breezzo <vialurt@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Bump hadoop aws version to 3.2.0 since the `fs.s3a.path.style.access` option is not available in 2.7.3 which makes it difficult to run spark jobs locally with minio.
I looked the version numbers in the Dockerfile https://github.com/feast-dev/feast-spark/blob/master/infra/docker/spark/Dockerfile
Maybe there any reasons why versions shouldn't be updated?

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
