### PR TITLE
Update redis host for e2e tests

### DIFF
--- a/infra/scripts/test-end-to-end-gcp.sh
+++ b/infra/scripts/test-end-to-end-gcp.sh
@@ -45,11 +45,11 @@ helm_install "js" "${DOCKER_REPOSITORY}" "${GIT_TAG}" "$NAMESPACE" \
   --set "feast-jobservice.envOverrides.FEAST_DATAPROC_PROJECT=kf-feast" \
   --set "feast-jobservice.envOverrides.FEAST_DATAPROC_REGION=us-central1" \
   --set "feast-jobservice.envOverrides.FEAST_SPARK_STAGING_LOCATION=gs://feast-templocation-kf-feast/" \
-  --set "feast-jobservice.envOverrides.FEAST_REDIS_HOST=10.128.0.105" \
+  --set "feast-jobservice.envOverrides.FEAST_REDIS_HOST=10.128.0.62" \
   --set "feast-jobservice.envOverrides.FEAST_REDIS_PORT=6379" \
   --set 'feast-online-serving.application-override\.yaml.feast.stores[0].type=REDIS_CLUSTER' \
   --set 'feast-online-serving.application-override\.yaml.feast.stores[0].name=online' \
-  --set 'feast-online-serving.application-override\.yaml.feast.stores[0].config.connection_string=10.128.0.105:6379' \
+  --set 'feast-online-serving.application-override\.yaml.feast.stores[0].config.connection_string=10.128.0.62:6379' \
   --set "redis.enabled=false" \
   --set "kafka.enabled=false"
 


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, the e2e tests for dataproc launcher is using a redis cluster installed on the kubernetes cluster as online storage. Often, the master and slave for the redis cluster goes down together, resulting in some slots not being covered and need to be fixed manually.

This PR changes the IP to point to the redis cluster provisioned on VM instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
