### PR TITLE
Fix SSTable name length restrictions during ingestion

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/bigtable/BigTableSinkRelation.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.functions.{col, length, struct, udf}
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.sql.types.{StringType, StructType}
+import feast.ingestion.utils.StringUtils
 import feast.ingestion.stores.serialization.Serializer
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.SparkEnv
@@ -154,7 +155,7 @@ class BigTableSinkRelation(
 
   private def tableName: String = {
     val entities = config.entityColumns.mkString("__")
-    s"${config.projectName}__${entities}"
+    StringUtils.trimAndHash(s"${config.projectName}__${entities}", maxTableNameLength)
   }
 
   private def joinEntityKey: UserDefinedFunction = udf { r: Row =>
@@ -164,6 +165,7 @@ class BigTableSinkRelation(
   private val metadataColumnFamily = "metadata"
   private val schemaKeyPrefix      = "schema#"
   private val emptyQualifier       = ""
+  private val maxTableNameLength   = 50
 
   private def isSystemColumn(name: String) =
     (config.entityColumns ++ Seq(config.timestampColumn)).contains(name)

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/CassandraSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/cassandra/CassandraSinkRelation.scala
@@ -16,6 +16,7 @@
  */
 package feast.ingestion.stores.cassandra
 
+import feast.ingestion.utils.StringUtils
 import feast.ingestion.stores.serialization.Serializer
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{col, lit, struct, udf}
@@ -63,8 +64,11 @@ class CassandraSinkRelation(
     writer.append()
   }
 
+  val maxTableNameLength = 48
+
   def sanitizedForCassandra(expr: String): String = {
-    expr.replace('-', '_')
+    val replacedString = expr.replace('-', '_')
+    StringUtils.trimAndHash(replacedString, maxTableNameLength)
   }
 
   val tableName = {

--- a/spark/ingestion/src/main/scala/feast/ingestion/utils/StringUtils.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/utils/StringUtils.scala
@@ -24,7 +24,8 @@ object StringUtils {
   }
 
   def trimAndHash(expr: String, maxLength: Int): String = {
-    val maxPrefixLength = 40
+    // Length 8 suffix as derived from murmurhash_32 implementation
+    val maxPrefixLength = maxLength - 8
     if (expr.length > maxLength)
       expr
         .take(maxPrefixLength)

--- a/spark/ingestion/src/main/scala/feast/ingestion/utils/StringUtils.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/utils/StringUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.utils
+
+import com.google.common.hash.Hashing
+
+object StringUtils {
+  private def suffixHash(expr: String): String = {
+    Hashing.murmur3_32().hashBytes(expr.getBytes).toString
+  }
+
+  def trimAndHash(expr: String, maxLength: Int): String = {
+    val maxPrefixLength = 40
+    if (expr.length > maxLength)
+      expr
+        .take(maxPrefixLength)
+        .concat(suffixHash(expr.substring(maxPrefixLength)))
+    else
+      expr
+  }
+}


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR fixes ingestion failure when table name length exceeds limit:
- 50 Characters (BigTable): [Docs](https://cloud.google.com/bigtable/quotas)
- 48 Characters (Cassandra): [Docs](https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/refLimits.html#:~:text=Table%20%2F%20CF%20name%20length%3A%2048,65535%20(2%2016%2D1))

[Relevant PR at `feast-java` repository that addresses this issue during retrieval](https://github.com/feast-dev/feast-java/pull/31).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
