### PR TITLE
Fix broken scheduled batch ingestion jobs

### DIFF
--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -529,6 +529,9 @@ class ScheduledBatchIngestionJobParameters(IngestionJobParameters):
     def get_job_type(self) -> SparkJobType:
         return SparkJobType.SCHEDULED_BATCH_INGESTION
 
+    def get_job_schedule(self) -> str:
+        return self._cron_schedule
+
     def get_arguments(self) -> List[str]:
         return super().get_arguments() + [
             "--mode",

--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -394,6 +394,7 @@ class KubernetesJobLauncher(JobLauncher):
         resource = _prepare_scheduled_job_resource(
             scheduled_job_template=self._scheduled_resource_template,
             scheduled_job_id=schedule_job_id,
+            job_schedule=ingestion_job_params.get_job_schedule(),
             job_template=self._resource_template,
             job_type=OFFLINE_TO_ONLINE_JOB_TYPE,
             main_application_file=jar_s3_path,

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -156,6 +156,7 @@ def _prepare_job_resource(
 def _prepare_scheduled_job_resource(
     scheduled_job_template: Dict[str, Any],
     scheduled_job_id: str,
+    job_schedule: str,
     job_template: Dict[str, Any],
     job_type: str,
     main_application_file: str,
@@ -170,6 +171,7 @@ def _prepare_scheduled_job_resource(
 ) -> Dict[str, Any]:
     """ Prepare ScheduledSparkApplication custom resource configs """
     scheduled_job = deepcopy(scheduled_job_template)
+    _add_keys(scheduled_job, ("spec",), dict(schedule=job_schedule))
 
     labels = {LABEL_JOBTYPE: job_type}
     if extra_labels:

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -298,10 +298,12 @@ def _submit_scheduled_job(
             api.create_namespaced_custom_object(
                 **_scheduled_crd_args(namespace), body=resource
             )
+            return
         else:
-            api.replace_namespaced_custom_object(
-                **_scheduled_crd_args(namespace), name=name, body=resource,
-            )
+            raise e
+    api.patch_namespaced_custom_object(
+        **_scheduled_crd_args(namespace), name=name, body=resource,
+    )
 
 
 def _list_jobs(

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -173,7 +173,7 @@ def _prepare_scheduled_job_resource(
     scheduled_job = deepcopy(scheduled_job_template)
     _add_keys(scheduled_job, ("spec",), dict(schedule=job_schedule))
 
-    labels = {LABEL_JOBTYPE: job_type}
+    labels = {LABEL_JOBID: scheduled_job_id, LABEL_JOBTYPE: job_type}
     if extra_labels:
         labels = {**labels, **extra_labels}
 

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -43,6 +43,7 @@ def test_schedule_batch_ingestion_jobs(
             plural="scheduledsparkapplications",
             name=f"feast-{feast_client.project}-{feature_table.name}".replace("_", "-"),
         )
+
     response = get_scheduled_spark_application()
     assert response["spec"]["schedule"] == "0 0 * * *"
     feast_spark_client.schedule_offline_to_online_ingestion(

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -34,11 +34,12 @@ def test_schedule_batch_ingestion_jobs(
     )
     config.load_incluster_config()
     k8s_api = client.CustomObjectsApi()
-    k8s_api.get_namespaced_custom_object(
+    response = k8s_api.get_namespaced_custom_object(
         group="sparkoperator.k8s.io",
         version="v1beta2",
         namespace=pytestconfig.getoption("k8s_namespace"),
         plural="scheduledsparkapplications",
         name=f"feast-{feast_client.project}-{feature_table.name}".replace("_", "-"),
     )
+    assert response["spec"]["schedule"] == "0 0 * * *"
     feast_spark_client.unschedule_offline_to_online_ingestion(feature_table)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, the functionality to schedule batch ingestion job is broken due to the following:

1. `cron_schedule` parameter have no effect because the parameter is not being used during the creation of the scheduledsparkapplication project.
2. `list_job` would be broken when there are scheduled spark application resource, due to missing `job id` label
3. `scheduledsparkapplication` cannot be updated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scheduled batch ingestion jobs will now work as intended
```
