### PR TITLE
Flush Ingestion Job termination log into kubernetes compatible destination

### DIFF
--- a/python/feast_spark/remote_job.py
+++ b/python/feast_spark/remote_job.py
@@ -89,10 +89,10 @@ class RemoteJobMixin:
         ).job
         return job.error_message
 
-    def wait_termination(self, timeout_sec=600):
+    def wait_termination(self, timeout_sec=None):
         status = self._wait_for_job_status(
             goal_status=[SparkJobStatus.COMPLETED, SparkJobStatus.FAILED],
-            timeout_seconds=timeout_sec,
+            timeout_seconds=timeout_sec or 600,
         )
 
         if status != SparkJobStatus.COMPLETED:

--- a/spark/ingestion/src/main/resources/log4j.properties
+++ b/spark/ingestion/src/main/resources/log4j.properties
@@ -1,0 +1,30 @@
+# Standard spark configuration #
+
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=WARN
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+
+# Feast #
+log4j.appender.termination=org.apache.log4j.FileAppender
+log4j.appender.termination.File=/dev/termination-log
+log4j.appender.file.Append=true
+log4j.appender.file.ImmediateFlush=true
+log4j.appender.termination.layout=org.apache.log4j.PatternLayout
+log4j.appender.termination.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+log4j.logger.feast=FATAL, termination

--- a/spark/ingestion/src/main/resources/log4j.properties
+++ b/spark/ingestion/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@
 
 log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
+log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
@@ -25,6 +25,6 @@ log4j.appender.termination.File=/dev/termination-log
 log4j.appender.file.Append=true
 log4j.appender.file.ImmediateFlush=true
 log4j.appender.termination.layout=org.apache.log4j.PatternLayout
-log4j.appender.termination.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.appender.termination.layout.ConversionPattern=%c{1}: %m%n
 
 log4j.logger.feast=FATAL, termination

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -128,7 +128,9 @@ object IngestionJob {
             try {
               BatchPipeline.createPipeline(sparkSession, config)
             } catch {
-              case e: Throwable => logger.fatal("Batch ingestion failed", e)
+              case e: Throwable =>
+                logger.fatal("Batch ingestion failed", e)
+                throw e
             } finally {
               sparkSession.close()
             }
@@ -137,7 +139,9 @@ object IngestionJob {
             try {
               StreamingPipeline.createPipeline(sparkSession, config).get.awaitTermination
             } catch {
-              case e: Throwable => logger.fatal("Streaming ingestion failed", e)
+              case e: Throwable =>
+                logger.fatal("Streaming ingestion failed", e)
+                throw e
             } finally {
               sparkSession.close()
             }


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Recently merged PR #74 added ability to obtain error message from historical retrieval job in SDK.
This PR extends this feature to expose errors from ingestion jobs as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
