### PR TITLE
Add configuration for bigquery entity staging location

### DIFF
--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -165,6 +165,16 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: That may help to control amount of write requests to storage
     SPARK_STREAMING_TRIGGERING_INTERVAL: Optional[str] = None
 
+    #: GCP project of the BigQuery dataset used to stage the entities during historical
+    #: feature retrieval. If not set, the GCP project of the feature table batch source
+    #: will be used instead.
+    BQ_STAGING_PROJECT: Optional[str] = None
+
+    #: BigQuery dataset used to stage the entities during historical feature retrieval.
+    #  If not set, the BigQuery dataset of the batch source will be used
+    #: instead.
+    BQ_STAGING_DATASET: Optional[str] = None
+
     def defaults(self):
         return {
             k: getattr(self, k)


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, if one or more feature table has a bigquery source and the input for get historical feature is a Panda dataframe, the entity will be staged on the same bigquery dataset as the first feature table's batch source.

This leads to permission issue, where the SDK user doesn't necessarily has the permission to create new table on the bigquery source.

This pull request allows user to specify additional option, such that it's possible for them to choose which bigquery dataset to stage the entities to.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now specify which BigQuery dataset to stage the entities (represented in Panda dataframe format) during historical feature retrieval.
```
