### PR TITLE
Use entity source project dataset for bigquery view creation

### DIFF
--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -271,7 +271,7 @@ def create_bq_view_of_joined_features_and_entities(
 ) -> BigQuerySource:
     """
     Creates BQ view that joins tables from `source` and `entity_source` with join key derived from `entity_names`.
-    Returns BigQuerySource with reference to created view.
+Returns BigQuerySource with reference to created view. The BQ view will be created in the same BQ dataset as `entity_source`.
     """
     from google.cloud import bigquery
 

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -8,7 +8,6 @@ from feast.config import Config
 from feast.data_format import ParquetFormat
 from feast.data_source import BigQuerySource, DataSource, FileSource, KafkaSource
 from feast.feature_table import FeatureTable
-from feast.staging.entities import create_bq_view_of_joined_features_and_entities
 from feast.staging.storage_client import get_staging_client
 from feast.value_type import ValueType
 from feast_spark.constants import ConfigOptions as opt
@@ -258,7 +257,7 @@ def table_reference_from_string(table_ref: str):
     """
     Parses reference string with format "{project}:{dataset}.{table}" into bigquery.TableReference
     """
-    import bigquery
+    from google.cloud import bigquery
 
     project, dataset_and_table = table_ref.split(":")
     dataset, table_id = dataset_and_table.split(".")
@@ -268,13 +267,14 @@ def table_reference_from_string(table_ref: str):
 
 
 def create_bq_view_of_joined_features_and_entities(
-        source: BigQuerySource, entity_source: BigQuerySource, entity_names: List[str]
+    source: BigQuerySource, entity_source: BigQuerySource, entity_names: List[str]
 ) -> BigQuerySource:
     """
     Creates BQ view that joins tables from `source` and `entity_source` with join key derived from `entity_names`.
     Returns BigQuerySource with reference to created view.
     """
-    import bigquery
+    from google.cloud import bigquery
+
     bq_client = bigquery.Client()
 
     source_ref = table_reference_from_string(source.bigquery_options.table_ref)

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, List, Optional, Union
 from urllib.parse import urlparse, urlunparse
 
@@ -251,6 +251,64 @@ def replace_bq_table_with_joined_view(
 
     return create_bq_view_of_joined_features_and_entities(
         feature_table.batch_source, entity_source, feature_table.entities,
+    )
+
+
+def table_reference_from_string(table_ref: str):
+    """
+    Parses reference string with format "{project}:{dataset}.{table}" into bigquery.TableReference
+    """
+    import bigquery
+
+    project, dataset_and_table = table_ref.split(":")
+    dataset, table_id = dataset_and_table.split(".")
+    return bigquery.TableReference(
+        bigquery.DatasetReference(project, dataset), table_id
+    )
+
+
+def create_bq_view_of_joined_features_and_entities(
+        source: BigQuerySource, entity_source: BigQuerySource, entity_names: List[str]
+) -> BigQuerySource:
+    """
+    Creates BQ view that joins tables from `source` and `entity_source` with join key derived from `entity_names`.
+    Returns BigQuerySource with reference to created view.
+    """
+    import bigquery
+    bq_client = bigquery.Client()
+
+    source_ref = table_reference_from_string(source.bigquery_options.table_ref)
+    entities_ref = table_reference_from_string(entity_source.bigquery_options.table_ref)
+
+    destination_ref = bigquery.TableReference(
+        bigquery.DatasetReference(entities_ref.project, entities_ref.dataset_id),
+        f"_view_{source_ref.table_id}_{datetime.now():%Y%m%d%H%M%s}",
+    )
+
+    view = bigquery.Table(destination_ref)
+
+    join_template = """
+    SELECT source.* FROM
+    `{entities.project}.{entities.dataset_id}.{entities.table_id}` entities
+    JOIN
+    `{source.project}.{source.dataset_id}.{source.table_id}` source
+    ON
+    ({entity_key})"""
+
+    view.view_query = join_template.format(
+        entities=entities_ref,
+        source=source_ref,
+        entity_key=" AND ".join([f"source.{e} = entities.{e}" for e in entity_names]),
+    )
+    view.expires = datetime.now() + timedelta(days=1)
+    bq_client.create_table(view)
+
+    return BigQuerySource(
+        event_timestamp_column=source.event_timestamp_column,
+        created_timestamp_column=source.created_timestamp_column,
+        table_ref=f"{view.project}:{view.dataset_id}.{view.table_id}",
+        field_mapping=source.field_mapping,
+        date_partition_column=source.date_partition_column,
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if one of the feature table requested comes from bigquery batch source, a bigquery view will be created on the same project and dataset as the batch source. It's quite possible that the jobservice will only have read permission, but not write permission. Therefore, in this PR, the view will be created on the same project and dataset as the source of the entities instead, which is configurable.

**Does this PR introduce a user-facing change?**:
During historical feature retrieval, if one of the feature table has bigquery batch source, big query views will be created on the same project and dataset as the entity source, rather than the feature table source. 

```release-note
Big query views will be created on the same project and dataset as the entity source, rather than the feature table source. 
```
