### PR TITLE
Use hash for schedule job id

### DIFF
--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -1,3 +1,4 @@
+import hashlib
 import random
 import string
 import time
@@ -63,14 +64,8 @@ def _generate_job_id() -> str:
 
 
 def _generate_scheduled_job_id(project: str, feature_table_name: str) -> str:
-    scheduled_job_id = f"feast-{project}-{feature_table_name}".replace("_", "-")
-    k8s_res_name_char_limit = 253
-
-    return (
-        scheduled_job_id
-        if len(scheduled_job_id) <= k8s_res_name_char_limit
-        else scheduled_job_id[:k8s_res_name_char_limit]
-    )
+    job_hash = hashlib.md5(f"{project}-{feature_table_name}".encode()).hexdigest()
+    return f"feast-{job_hash}"
 
 
 def _truncate_label(label: str) -> str:

--- a/tests/e2e/test_job_scheduling.py
+++ b/tests/e2e/test_job_scheduling.py
@@ -1,3 +1,4 @@
+import hashlib
 import uuid
 
 import pytest as pytest
@@ -36,12 +37,17 @@ def test_schedule_batch_ingestion_jobs(
     k8s_api = client.CustomObjectsApi()
 
     def get_scheduled_spark_application():
+        job_hash = hashlib.md5(
+            f"{feast_client.project}-{feature_table.name}".encode()
+        ).hexdigest()
+        resource_name = f"feast-{job_hash}"
+
         return k8s_api.get_namespaced_custom_object(
             group="sparkoperator.k8s.io",
             version="v1beta2",
             namespace=pytestconfig.getoption("k8s_namespace"),
             plural="scheduledsparkapplications",
-            name=f"feast-{feast_client.project}-{feature_table.name}".replace("_", "-"),
+            name=resource_name,
         )
 
     response = get_scheduled_spark_application()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Spark driver pods has a label named `sparkoperator.k8s.io/app-name`, where the value is the scheduledsparkapplication CRD name with a timestamp suffix. As such, this limits the number of characters which we can use for the scheduled job name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scheduled spark application name will now take the form of `feast-{md5 hash}`, where the hash value is derived from the project and feature table.
```
