### PR TITLE
Fix mypy-protobuf version requirement

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -50,7 +50,7 @@ REQUIRED = [
     "google-cloud-dataproc==2.0.2",
     "kubernetes==12.0.*",
     "grpcio-tools==1.31.0",
-    "mypy-protobuf",
+    "mypy-protobuf==2.5",
     "croniter==1.*",
 ]
 


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@go-jek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The version requirement for mypy-protobuf is not fixed, which lead to grpcio version requirement conflict when publishing pypi package.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
