### PR TITLE
Speed-up join in historical retrieval by replacing pandas with native spark

### DIFF
--- a/python/feast_spark/pyspark/historical_feature_retrieval_job.py
+++ b/python/feast_spark/pyspark/historical_feature_retrieval_job.py
@@ -569,7 +569,7 @@ def _make_time_filter_pandas_udf(
     entity_br = spark.sparkContext.broadcast(
         entity_pandas.rename(
             columns={entity_event_timestamp_column: EVENT_TIMESTAMP_ALIAS}
-        ).set_index(entity_names)
+        ).set_index(entity_names).sort_index()
     )
 
     @pandas_udf(BooleanType(), PandasUDFType.SCALAR)

--- a/python/feast_spark/pyspark/historical_feature_retrieval_job.py
+++ b/python/feast_spark/pyspark/historical_feature_retrieval_job.py
@@ -8,18 +8,10 @@ from datetime import timedelta
 from logging.config import dictConfig
 from typing import Any, Dict, List, NamedTuple, Optional
 
-import numpy as np
-import pandas as pd
 from pyspark.sql import DataFrame, SparkSession, Window
-from pyspark.sql.functions import (
-    col,
-    expr,
-    monotonically_increasing_id,
-    row_number,
-    struct,
-)
-from pyspark.sql.pandas.functions import PandasUDFType, pandas_udf
-from pyspark.sql.types import BooleanType, LongType
+from pyspark.sql import functions as func
+from pyspark.sql.functions import col, expr, monotonically_increasing_id, row_number
+from pyspark.sql.types import LongType
 
 EVENT_TIMESTAMP_ALIAS = "event_timestamp"
 CREATED_TIMESTAMP_ALIAS = "created_timestamp"
@@ -557,49 +549,19 @@ class SchemaError(Exception):
     pass
 
 
-def _make_time_filter_pandas_udf(
-    spark: SparkSession,
-    entity_pandas: pd.DataFrame,
-    feature_table: FeatureTable,
-    entity_event_timestamp_column: str,
-):
-    entity_names = feature_table.entity_names
-    max_age = feature_table.max_age
-
-    entity_br = spark.sparkContext.broadcast(
-        entity_pandas.rename(
-            columns={entity_event_timestamp_column: EVENT_TIMESTAMP_ALIAS}
-        ).set_index(entity_names).sort_index()
-    )
-
-    @pandas_udf(BooleanType(), PandasUDFType.SCALAR)
-    def within_time_boundaries(features: pd.DataFrame) -> pd.Series:
-        features["_row_id"] = np.arange(len(features))
-        features.set_index(entity_names, inplace=True)
-        merged = features.join(
-            entity_br.value, how="left", lsuffix="_feature", rsuffix="_entity",
-        )
-        merged["distance"] = (
-            merged[f"{EVENT_TIMESTAMP_ALIAS}_entity"]
-            - merged[f"{EVENT_TIMESTAMP_ALIAS}_feature"]
-        )
-        merged["within"] = merged["distance"].dt.total_seconds().between(0, max_age)
-
-        return merged.groupby(["_row_id"]).max()["within"]
-
-    return within_time_boundaries
-
-
 def _filter_feature_table_by_time_range(
-    spark: SparkSession,
     feature_table_df: DataFrame,
     feature_table: FeatureTable,
     feature_event_timestamp_column: str,
-    entity_pandas: pd.DataFrame,
+    entity_df: DataFrame,
     entity_event_timestamp_column: str,
 ):
-    entity_max_timestamp = entity_pandas[entity_event_timestamp_column].max()
-    entity_min_timestamp = entity_pandas[entity_event_timestamp_column].min()
+    entity_max_timestamp = entity_df.agg(
+        {entity_event_timestamp_column: "max"}
+    ).collect()[0][0]
+    entity_min_timestamp = entity_df.agg(
+        {entity_event_timestamp_column: "min"}
+    ).collect()[0][0]
 
     feature_table_timestamp_filter = (
         col(feature_event_timestamp_column).between(
@@ -613,16 +575,26 @@ def _filter_feature_table_by_time_range(
     time_range_filtered_df = feature_table_df.filter(feature_table_timestamp_filter)
 
     if feature_table.max_age:
-        within_time_boundaries_udf = _make_time_filter_pandas_udf(
-            spark, entity_pandas, feature_table, entity_event_timestamp_column
+        time_range_filtered_df = (
+            time_range_filtered_df.join(
+                entity_df.withColumnRenamed(
+                    entity_event_timestamp_column, f"{EVENT_TIMESTAMP_ALIAS}_entity"
+                ),
+                on=feature_table.entity_names,
+                how="left",
+            )
+            .filter(f"{EVENT_TIMESTAMP_ALIAS}_entity is not null")
+            .withColumn(
+                "within_time_boundaries",
+                func.abs(
+                    col(f"{EVENT_TIMESTAMP_ALIAS}_entity").cast("long")
+                    - col(EVENT_TIMESTAMP_ALIAS).cast("long")
+                )
+                <= feature_table.max_age,
+            )
+            .filter("within_time_boundaries = true")
+            .select(time_range_filtered_df.columns)
         )
-
-        time_range_filtered_df = time_range_filtered_df.withColumn(
-            "within_time_boundaries",
-            within_time_boundaries_udf(
-                struct(feature_table.entity_names + [feature_event_timestamp_column])
-            ),
-        ).filter("within_time_boundaries = true")
 
     return time_range_filtered_df
 
@@ -806,15 +778,14 @@ def retrieve_historical_features(
                 f"{expected_entity.name} ({expected_entity.spark_type}) is not present in the entity dataframe."
             )
 
-    entity_pandas = entity_df.toPandas()
+    entity_df.cache()
 
     feature_table_dfs = [
         _filter_feature_table_by_time_range(
-            spark,
             feature_table_df,
             feature_table,
             feature_table_source.event_timestamp_column,
-            entity_pandas,
+            entity_df,
             entity_source.event_timestamp_column,
         )
         for feature_table_df, feature_table, feature_table_source in zip(

--- a/python/tests/test_historical_feature_retrieval.py
+++ b/python/tests/test_historical_feature_retrieval.py
@@ -21,6 +21,7 @@ from feast_spark.pyspark.historical_feature_retrieval_job import (
     Field,
     SchemaError,
     as_of_join,
+    filter_feature_table_by_time_range,
     join_entity_to_feature_tables,
     retrieve_historical_features,
 )
@@ -182,91 +183,6 @@ def assert_dataframe_equal(left: DataFrame, right: DataFrame):
     assert is_content_equal
 
 
-def test_join_without_max_age(
-    spark: SparkSession,
-    single_entity_schema: StructType,
-    customer_feature_schema: StructType,
-):
-    entity_data = [
-        (1001, datetime(year=2020, month=8, day=31)),
-        (1001, datetime(year=2020, month=9, day=1)),
-        (1001, datetime(year=2020, month=9, day=2)),
-        (1001, datetime(year=2020, month=9, day=3)),
-        (2001, datetime(year=2020, month=9, day=2)),
-        (3001, datetime(year=2020, month=9, day=1)),
-    ]
-    entity_df = spark.createDataFrame(
-        spark.sparkContext.parallelize(entity_data), single_entity_schema
-    )
-
-    feature_table_data = [
-        (
-            1001,
-            datetime(year=2020, month=9, day=1),
-            datetime(year=2020, month=9, day=1),
-            50.0,
-        ),
-        (
-            1001,
-            datetime(year=2020, month=9, day=1),
-            datetime(year=2020, month=9, day=2),
-            100.0,
-        ),
-        (
-            2001,
-            datetime(year=2020, month=9, day=1),
-            datetime(year=2020, month=9, day=1),
-            400.0,
-        ),
-        (
-            1001,
-            datetime(year=2020, month=9, day=2),
-            datetime(year=2020, month=9, day=1),
-            200.0,
-        ),
-        (
-            1001,
-            datetime(year=2020, month=9, day=4),
-            datetime(year=2020, month=9, day=1),
-            300.0,
-        ),
-    ]
-    feature_table_df = spark.createDataFrame(
-        spark.sparkContext.parallelize(feature_table_data), customer_feature_schema
-    )
-
-    feature_table = FeatureTable(
-        name="transactions",
-        features=[Field("daily_transactions", "double")],
-        entities=[Field("customer_id", "int32")],
-    )
-
-    joined_df = as_of_join(
-        entity_df, "event_timestamp", feature_table_df, feature_table,
-    )
-
-    expected_joined_schema = StructType(
-        [
-            StructField("customer_id", IntegerType()),
-            StructField("event_timestamp", TimestampType()),
-            StructField("transactions__daily_transactions", FloatType()),
-        ]
-    )
-    expected_joined_data = [
-        (1001, datetime(year=2020, month=8, day=31), None),
-        (1001, datetime(year=2020, month=9, day=1), 100.0,),
-        (1001, datetime(year=2020, month=9, day=2), 200.0,),
-        (1001, datetime(year=2020, month=9, day=3), 200.0,),
-        (2001, datetime(year=2020, month=9, day=2), 400.0,),
-        (3001, datetime(year=2020, month=9, day=1), None),
-    ]
-    expected_joined_df = spark.createDataFrame(
-        spark.sparkContext.parallelize(expected_joined_data), expected_joined_schema
-    )
-
-    assert_dataframe_equal(joined_df, expected_joined_df)
-
-
 def test_join_with_max_age(
     spark: SparkSession,
     single_entity_schema: StructType,
@@ -303,6 +219,14 @@ def test_join_with_max_age(
         features=[Field("daily_transactions", "double")],
         entities=[Field("customer_id", "int32")],
         max_age=86400,
+    )
+
+    feature_table_df = filter_feature_table_by_time_range(
+        feature_table_df,
+        feature_table,
+        "event_timestamp",
+        entity_df,
+        "event_timestamp",
     )
 
     joined_df = as_of_join(
@@ -378,7 +302,13 @@ def test_join_with_composite_entity(
         entities=[Field("customer_id", "int32"), Field("driver_id", "int32")],
         max_age=86400,
     )
-
+    feature_table_df = filter_feature_table_by_time_range(
+        feature_table_df,
+        feature_table,
+        "event_timestamp",
+        entity_df,
+        "event_timestamp",
+    )
     joined_df = as_of_join(
         entity_df, "event_timestamp", feature_table_df, feature_table,
     )
@@ -439,8 +369,15 @@ def test_select_subset_of_columns_as_entity_primary_keys(
         name="transactions",
         features=[Field("daily_transactions", "double")],
         entities=[Field("customer_id", "int32")],
+        max_age=86400,
     )
-
+    feature_table_df = filter_feature_table_by_time_range(
+        feature_table_df,
+        feature_table,
+        "event_timestamp",
+        entity_df,
+        "event_timestamp",
+    )
     joined_df = as_of_join(
         entity_df, "event_timestamp", feature_table_df, feature_table,
     )
@@ -503,6 +440,13 @@ def test_multiple_join(
         entities=[Field("customer_id", "int32")],
         max_age=86400,
     )
+    customer_table_df = filter_feature_table_by_time_range(
+        customer_table_df,
+        customer_table,
+        "event_timestamp",
+        entity_df,
+        "event_timestamp",
+    )
 
     driver_table_data = [
         (
@@ -538,8 +482,11 @@ def test_multiple_join(
         name="bookings",
         features=[Field("completed_bookings", "int32")],
         entities=[Field("driver_id", "int32")],
+        max_age=7 * 86400,
     )
-
+    driver_table_df = filter_feature_table_by_time_range(
+        driver_table_df, driver_table, "event_timestamp", entity_df, "event_timestamp",
+    )
     joined_df = join_entity_to_feature_tables(
         entity_df,
         "event_timestamp",
@@ -665,6 +612,7 @@ def test_historical_feature_retrieval_with_mapping(spark: SparkSession):
         "name": "bookings",
         "entities": [{"name": "customer_id", "type": "int32"}],
         "features": [{"name": "total_bookings", "type": "int32"}],
+        "max_age": 86400,
     }
 
     joined_df = retrieve_historical_features(
@@ -735,6 +683,7 @@ def test_large_historical_feature_retrieval(
         "name": "feature",
         "entities": [{"name": "customer_id", "type": "int32"}],
         "features": [{"name": "total_bookings", "type": "int32"}],
+        "max_age": 86400,
     }
 
     joined_df = retrieve_historical_features(
@@ -792,11 +741,13 @@ def test_historical_feature_retrieval_with_schema_errors(spark: SparkSession):
         "name": "bookings",
         "entities": [{"name": "driver_id", "type": "int32"}],
         "features": [{"name": "completed_bookings", "type": "int32"}],
+        "max_age": 86400,
     }
     booking_table_missing_features = {
         "name": "bookings",
         "entities": [{"name": "driver_id", "type": "int32"}],
         "features": [{"name": "nonexist_feature", "type": "int32"}],
+        "max_age": 86400,
     }
 
     with pytest.raises(SchemaError):
@@ -843,6 +794,7 @@ def test_implicit_type_conversion(spark: SparkSession,):
         "name": "transactions",
         "entities": [{"name": "customer_id", "type": "int32"}],
         "features": [{"name": "daily_transactions", "type": "float"}],
+        "max_age": 86400,
     }
 
     joined_df = retrieve_historical_features(

--- a/tests/e2e/fixtures/client.py
+++ b/tests/e2e/fixtures/client.py
@@ -74,7 +74,7 @@ def feast_client(
             **job_service_env,
         )
     elif pytestconfig.getoption("env") == "aws":
-        return Client(
+        c = Client(
             core_url=f"{feast_core[0]}:{feast_core[1]}",
             serving_url=f"{feast_serving[0]}:{feast_serving[1]}",
             spark_launcher="emr",
@@ -92,7 +92,7 @@ def feast_client(
             enable_auth=pytestconfig.getoption("enable_auth"),
         )
     elif pytestconfig.getoption("env") == "k8s":
-        return Client(
+        c = Client(
             core_url=f"{feast_core[0]}:{feast_core[1]}",
             serving_url=f"{feast_serving[0]}:{feast_serving[1]}",
             historical_feature_output_location=os.path.join(


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Turns out that `Pandas.merge` is too slow, so it's better to use spark join instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
