### PR TITLE
Add persistent checkpoint to historical retrieval spark job

### DIFF
--- a/python/feast_spark/pyspark/abc.py
+++ b/python/feast_spark/pyspark/abc.py
@@ -151,6 +151,7 @@ class RetrievalJobParameters(SparkJobParameters):
         entity_source: Dict,
         destination: Dict,
         extra_packages: Optional[List[str]] = None,
+        checkpoint_path: Optional[str] = None,
     ):
         """
         Args:
@@ -265,6 +266,7 @@ class RetrievalJobParameters(SparkJobParameters):
         self._entity_source = entity_source
         self._destination = destination
         self._extra_packages = extra_packages if extra_packages else []
+        self._checkpoint_path = checkpoint_path
 
     def get_name(self) -> str:
         all_feature_tables_names = [ft["name"] for ft in self._feature_tables]
@@ -285,7 +287,7 @@ class RetrievalJobParameters(SparkJobParameters):
         def json_b64_encode(obj) -> str:
             return b64encode(json.dumps(obj).encode("utf8")).decode("ascii")
 
-        return [
+        args = [
             "--feature-tables",
             json_b64_encode(self._feature_tables),
             "--feature-tables-sources",
@@ -295,6 +297,9 @@ class RetrievalJobParameters(SparkJobParameters):
             "--destination",
             json_b64_encode(self._destination),
         ]
+        if self._checkpoint_path:
+            args.extend(["--checkpoint", self._checkpoint_path])
+        return args
 
     def get_destination_path(self) -> str:
         return self._destination["path"]

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -233,6 +233,7 @@ def start_historical_feature_retrieval_job(
             ],
             destination={"format": output_format, "path": output_path},
             extra_packages=extra_packages,
+            checkpoint_path=client.config.get(opt.CHECKPOINT_PATH),
         )
     )
 


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

To handle several feature table in historical retrieval we need checkpointing to prevent data recalculation. Since datasets could be bigger than executor memory it's better to use persistent checkpoint location.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
