### PR TITLE
Remove spark bigquery package download at run time

### DIFF
--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -13,7 +13,6 @@ from kubernetes.client.api import CustomObjectsApi
 
 from feast.staging.storage_client import AbstractStagingClient
 from feast_spark.pyspark.abc import (
-    BQ_SPARK_PACKAGE,
     BatchIngestionJob,
     BatchIngestionJobParameters,
     JobLauncher,
@@ -347,7 +346,7 @@ class KubernetesJobLauncher(JobLauncher):
             job_type=OFFLINE_TO_ONLINE_JOB_TYPE,
             main_application_file=jar_s3_path,
             main_class=ingestion_job_params.get_class_name(),
-            packages=[BQ_SPARK_PACKAGE],
+            packages=[],
             jars=[],
             extra_metadata={},
             azure_credentials=self._get_azure_credentials(),
@@ -399,7 +398,7 @@ class KubernetesJobLauncher(JobLauncher):
             job_type=OFFLINE_TO_ONLINE_JOB_TYPE,
             main_application_file=jar_s3_path,
             main_class=ingestion_job_params.get_class_name(),
-            packages=[BQ_SPARK_PACKAGE],
+            packages=[],
             jars=[],
             extra_metadata={},
             azure_credentials=self._get_azure_credentials(),
@@ -460,7 +459,7 @@ class KubernetesJobLauncher(JobLauncher):
             job_type=STREAM_TO_ONLINE_JOB_TYPE,
             main_application_file=jar_s3_path,
             main_class=ingestion_job_params.get_class_name(),
-            packages=[BQ_SPARK_PACKAGE],
+            packages=[],
             jars=extra_jar_paths,
             extra_metadata={METADATA_JOBHASH: job_hash},
             azure_credentials=self._get_azure_credentials(),

--- a/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s_utils.py
@@ -147,7 +147,8 @@ def _prepare_job_resource(
     _add_keys(job, ("spec", "sparkConf"), extra_metadata)
     _add_keys(job, ("spec", "sparkConf"), azure_credentials)
 
-    _append_items(job, ("spec", "deps", "packages"), packages)
+    if len(packages) > 1:
+        _append_items(job, ("spec", "deps", "packages"), packages)
     _append_items(job, ("spec", "deps", "jars"), jars)
 
     return job


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Spark bigquery package is not needed for kubernetes launcher as the dependencies is already present in the docker image. Adding the package result in run failure when the dependencies artifact cannot be resolved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
