### PR TITLE
Enable sql expression evaluation in fieldMapping for historical retrieval

### DIFF
--- a/python/feast_spark/pyspark/historical_feature_retrieval_job.py
+++ b/python/feast_spark/pyspark/historical_feature_retrieval_job.py
@@ -14,6 +14,7 @@ from pyspark.sql import functions as func
 from pyspark.sql.functions import (
     broadcast,
     col,
+    expr,
     monotonically_increasing_id,
     row_number,
 )
@@ -322,7 +323,9 @@ class FileDestination(NamedTuple):
 def _map_column(df: DataFrame, col_mapping: Dict[str, str]):
     source_to_alias_map = {v: k for k, v in col_mapping.items()}
     projection = [
-        col(col_name).alias(source_to_alias_map.get(col_name, col_name))
+        expr(col_mapping.get(col_name, col_name)).alias(
+            source_to_alias_map.get(col_name, col_name)
+        )
         for col_name in df.columns
     ]
     return df.select(projection)

--- a/python/tests/test_historical_feature_retrieval.py
+++ b/python/tests/test_historical_feature_retrieval.py
@@ -47,7 +47,7 @@ def large_entity_csv_file(pytestconfig, spark):
     file_path = os.path.join(temp_dir, "large_entity")
     entity_schema = StructType(
         [
-            StructField("customer_id", IntegerType()),
+            StructField("id", IntegerType()),
             StructField("event_timestamp", TimestampType()),
         ]
     )


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

FieldMapping logic is synchronized between ingestion jobs and historical retrieval.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
