### PR TITLE
Configurable templates by job type for spark kubernetes jobs

### DIFF
--- a/infra/charts/feast-spark/charts/feast-jobservice/templates/configmap.yaml
+++ b/infra/charts/feast-spark/charts/feast-jobservice/templates/configmap.yaml
@@ -13,4 +13,10 @@ metadata:
 data:
   jobTemplate.yaml: |
 {{- toYaml .Values.sparkOperator.jobTemplate | nindent 4 }}
+  batchJobTemplate.yaml: |
+{{- toYaml .Values.sparkOperator.batchJobTemplate | nindent 4 }}
+  streamJobTemplate.yaml: |
+{{- toYaml .Values.sparkOperator.streamJobTemplate | nindent 4 }}
+  historicalJobTemplate.yaml: |
+{{- toYaml .Values.sparkOperator.historicalJobTemplate | nindent 4 }}
 {{- end }}

--- a/infra/charts/feast-spark/charts/feast-jobservice/templates/deployment.yaml
+++ b/infra/charts/feast-spark/charts/feast-jobservice/templates/deployment.yaml
@@ -76,6 +76,12 @@ spec:
         {{- if .Values.sparkOperator.enabled }}
         - name: FEAST_SPARK_K8S_JOB_TEMPLATE_PATH
           value: /etc/configs/jobTemplate.yaml
+        - name: SPARK_K8S_BATCH_INGESTION_TEMPLATE_PATH
+          value: /etc/configs/batchJobTemplate.yaml
+        - name: SPARK_K8S_STREAM_INGESTION_TEMPLATE_PATH
+          value: /etc/configs/streamJobTemplate.yaml
+        - name: SPARK_K8S_HISTORICAL_RETRIEVAL_TEMPLATE_PATH
+          value: /etc/configs/historicalJobTemplate.yaml
         {{- end }}
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}

--- a/infra/charts/feast-spark/charts/feast-jobservice/values.yaml
+++ b/infra/charts/feast-spark/charts/feast-jobservice/values.yaml
@@ -26,6 +26,10 @@ sparkOperator:
   enabled: false
   # sparkOperator.jobTemplate -- Content of the job template, in yaml format
   jobTemplate: {}
+  # specialized job templates by job types
+  batchJobTemplate: {}
+  streamJobTemplate: {}
+  historicalJobTemplate: {}
 
 prometheus:
   # prometheus.enabled -- Flag to enable scraping of metrics

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -93,6 +93,15 @@ class ConfigOptions(metaclass=ConfigMeta):
     # SparkApplication resource template
     SPARK_K8S_JOB_TEMPLATE_PATH = None
 
+    # SparkApplication resource template for Batch Ingestion Jobs
+    SPARK_K8S_BATCH_INGESTION_TEMPLATE_PATH: Optional[str] = ""
+
+    # SparkApplication resource template for Stream Ingestion Jobs
+    SPARK_K8S_STREAM_INGESTION_TEMPLATE_PATH: Optional[str] = ""
+
+    # SparkApplication resource template for Historical Retrieval Jobs
+    SPARK_K8S_HISTORICAL_RETRIEVAL_TEMPLATE_PATH: Optional[str] = ""
+
     #: File format of historical retrieval features
     HISTORICAL_FEATURE_OUTPUT_FORMAT: str = "parquet"
 

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -73,7 +73,16 @@ def _k8s_launcher(config: Config) -> JobLauncher:
 
     return k8s.KubernetesJobLauncher(
         namespace=config.get(opt.SPARK_K8S_NAMESPACE),
-        resource_template_path=config.get(opt.SPARK_K8S_JOB_TEMPLATE_PATH, None),
+        generic_resource_template_path=config.get(opt.SPARK_K8S_JOB_TEMPLATE_PATH),
+        batch_ingestion_resource_template_path=config.get(
+            opt.SPARK_K8S_BATCH_INGESTION_TEMPLATE_PATH, None
+        ),
+        stream_ingestion_resource_template_path=config.get(
+            opt.SPARK_K8S_STREAM_INGESTION_TEMPLATE_PATH, None
+        ),
+        historical_retrieval_resource_template_path=config.get(
+            opt.SPARK_K8S_HISTORICAL_RETRIEVAL_TEMPLATE_PATH, None
+        ),
         staging_location=staging_location,
         incluster=config.getboolean(opt.SPARK_K8S_USE_INCLUSTER_CONFIG),
         staging_client=get_staging_client(staging_uri.scheme, config),


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR introduces ability to configure each spark job type separately when using kubernetes launcher.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
