### PR TITLE
Reduce redis hash map memory foot print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ sdk/python/docs/html
 .bloop
 .metals
 *.code-workspace
+
+spark/ingestion/src/test/resources/python/libs.tar.gz
+spark/ingestion/src/test/resources/python/udf.pickle

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/Persistence.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/Persistence.scala
@@ -41,8 +41,7 @@ trait Persistence {
       pipeline: PipelineBinaryCommands,
       key: Array[Byte],
       row: Row,
-      expiryTimestamp: Timestamp,
-      maxExpiryTimestamp: Timestamp
+      expiryTimestamp: Option[Timestamp]
   ): Unit
 
   /**

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -146,8 +146,9 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
       storedValues should beStoredRow(
         Map(
           featureKeyEncoder("unique_drivers") -> r.getUniqueDrivers,
-          "_ts:driver-fs"                     -> new java.sql.Timestamp(r.getEventTimestamp.getSeconds * 1000),
-          "_ex:driver-fs"                     -> new java.sql.Timestamp(Timestamps.MAX_VALUE.getSeconds * 1000)
+          murmurHashHexString("_ts:driver-fs") -> new java.sql.Timestamp(
+            r.getEventTimestamp.getSeconds * 1000
+          )
         )
       )
       val keyTTL = jedis.ttl(encodedEntityKey).toInt
@@ -178,8 +179,10 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
         storedValues should beStoredRow(
           Map(
             featureKeyEncoder("unique_drivers") -> r.getUniqueDrivers,
-            "_ts:driver-fs"                     -> new java.sql.Timestamp(r.getEventTimestamp.getSeconds * 1000),
-            "_ex:driver-fs" -> new java.sql.Timestamp(
+            murmurHashHexString("_ts:driver-fs") -> new java.sql.Timestamp(
+              r.getEventTimestamp.getSeconds * 1000
+            ),
+            "_ex" -> new java.sql.Timestamp(
               (r.getEventTimestamp.getSeconds + maxAge) * 1000
             )
           )
@@ -208,11 +211,9 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
           Map(
             featureKeyEncoder("unique_drivers")                   -> r.getUniqueDrivers,
             featureKeyEncoderSecondFeatureTable("unique_drivers") -> r.getUniqueDrivers,
-            "_ts:driver-fs"                                       -> new java.sql.Timestamp(r.getEventTimestamp.getSeconds * 1000),
-            "_ex:driver-fs" -> new java.sql.Timestamp(
-              (r.getEventTimestamp.getSeconds + maxAge) * 1000
-            ),
-            "_ex:driver-fs-2" -> new java.sql.Timestamp(Timestamps.MAX_VALUE.getSeconds * 1000)
+            murmurHashHexString("_ts:driver-fs") -> new java.sql.Timestamp(
+              r.getEventTimestamp.getSeconds * 1000
+            )
           )
         )
         val keyTTL = jedis.ttl(encodedEntityKey).toInt
@@ -432,7 +433,7 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
       Map(
         customFeatureKeyEncoder("feature1") -> row.feature1,
         customFeatureKeyEncoder("feature2") -> row.feature2,
-        "_ts:test-fs"                       -> row.eventTimestamp
+        murmurHashHexString("_ts:test-fs")  -> row.eventTimestamp
       )
     )
 


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
A large part of the memory footprint for Feast features is due to storage of timestamps as plain string, that includes the name of the feature table. This merge request will:
- Hash the event timestamp fields
- Make expiry timestamp not feature table specific

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Redis TTL will only be changed if the new expiry date is later than the existing expiry date
```
