### PR TITLE
add config setting for whitelisting feast job types

### DIFF
--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -172,6 +172,9 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Log path of EMR cluster
     EMR_LOG_LOCATION: Optional[str] = None
 
+    #: Whitelisted Feast Job Types
+    WHITELISTED_JOB_TYPES: Optional[str] = None
+
     #: Whitelisted Feast projects
     WHITELISTED_PROJECTS: Optional[str] = None
 

--- a/python/tests/test_jobservice_servicer.py
+++ b/python/tests/test_jobservice_servicer.py
@@ -21,3 +21,19 @@ def test_feature_table_whitelist():
         job_servicer = JobServiceServicer(job_client)
         assert not job_servicer.is_feature_table_whitelisted("project2", "table1")
         assert job_servicer.is_feature_table_whitelisted("project1", "table1")
+
+
+def test_job_type_default_whitelist():
+    feast_client = Client()
+    job_client = JobClient(feast_client)
+    job_servicer = JobServiceServicer(job_client)
+    assert job_servicer.is_job_type_whitelisted("STREAM_INGESTION")
+
+
+def test_job_type_whitelist():
+    feast_client = Client(whitelisted_job_types="STREAM_INGESTION,BATCH_INGESTION")
+    job_client = JobClient(feast_client)
+    job_servicer = JobServiceServicer(job_client)
+    assert job_servicer.is_job_type_whitelisted("STREAM_INGESTION")
+    assert job_servicer.is_job_type_whitelisted("BATCH_INGESTION")
+    assert not job_servicer.is_job_type_whitelisted("HISTORICAL_RETRIEVAL")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds a configuration setting to whitelist one or many feast job types.

This is required for the purpose of migrating data to Redis Enterprise. We plan to mirror all the requests for batch ingestion to a new jobservice that will schedule ingestion jobs for the new storage backend, but at the same time, we don’t want to duplicate the number of historical retrieval jobs.
Hence, we will need to add new configuration on job service such that all historical retrieval job will be rejected if we specifically add configuration that allows only certain jobs to be run.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Job types can be whitelisted using this configuration setting
eg. 
whitelisted_job_types ="STREAM_INGESTION,BATCH_INGESTION"
```
