### PR TITLE
Add ingestion job health metrics retrieval

### DIFF
--- a/protos/feast_spark/api/JobService.proto
+++ b/protos/feast_spark/api/JobService.proto
@@ -49,6 +49,9 @@ service JobService {
 
     // Get details of a single job
     rpc GetJob (GetJobRequest) returns (GetJobResponse);
+
+    // Get ingestion health metrics for a Feature Table
+    rpc GetHealthMetrics (GetHealthMetricsRequest) returns (GetHealthMetricsResponse);
 }
 
 
@@ -241,3 +244,13 @@ message CancelJobRequest{
 }
 
 message CancelJobResponse {}
+
+message GetHealthMetricsRequest {
+  string project = 1;
+  repeated string table_names = 2;
+}
+
+message GetHealthMetricsResponse {
+  repeated string passed = 1;
+  repeated string failed = 2;
+}

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -459,16 +459,13 @@ class Client:
             )
 
     def get_health_metrics(
-        self,
-        project: str,
-        table_names: List[str],
+        self, project: str, table_names: List[str],
     ) -> Dict[str, List[str]]:
         if not self._use_job_service:
             return get_health_metrics(self, project, table_names)
         else:
             request = GetHealthMetricsRequest(
-                project=cast(str, project),
-                table_names=table_names,
+                project=cast(str, project), table_names=table_names,
             )
             response = self._job_service.GetHealthMetrics(request)
             return {"passed": response.passed, "failed": response.failed}

--- a/python/feast_spark/client.py
+++ b/python/feast_spark/client.py
@@ -3,9 +3,10 @@ import os
 import uuid
 from datetime import datetime
 from itertools import groupby
-from typing import List, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast
 
 import pandas as pd
+import redis
 from croniter import croniter
 
 import feast
@@ -19,6 +20,7 @@ from feast.staging.entities import (
     table_reference_from_string,
 )
 from feast_spark.api.JobService_pb2 import (
+    GetHealthMetricsRequest,
     GetHistoricalFeaturesRequest,
     GetJobRequest,
     ListJobsRequest,
@@ -31,6 +33,7 @@ from feast_spark.api.JobService_pb2_grpc import JobServiceStub
 from feast_spark.constants import ConfigOptions as opt
 from feast_spark.pyspark.abc import RetrievalJob, SparkJob
 from feast_spark.pyspark.launcher import (
+    get_health_metrics,
     get_job_by_id,
     list_jobs,
     schedule_offline_to_online_ingestion,
@@ -59,6 +62,14 @@ class Client:
         self._feast = feast_client
         self._job_service_stub: Optional[JobServiceStub] = None
 
+        if self.config.exists(opt.SPARK_METRICS_REDIS_HOST) and self.config.exists(
+            opt.SPARK_METRICS_REDIS_PORT
+        ):
+            self._metrics_redis = redis.Redis(
+                host=self.config.get(opt.SPARK_METRICS_REDIS_HOST),
+                port=self.config.get(opt.SPARK_METRICS_REDIS_PORT),
+            )
+
     @property
     def config(self) -> Config:
         return self._feast._config
@@ -74,6 +85,10 @@ class Client:
     @property
     def _use_job_service(self) -> bool:
         return self.config.exists(opt.JOB_SERVICE_URL)
+
+    @property
+    def metrics_redis(self) -> redis.Redis:
+        return self._metrics_redis
 
     @property
     def _job_service(self):
@@ -222,7 +237,7 @@ class Client:
             )
 
     def get_historical_features_df(
-        self, feature_refs: List[str], entity_source: Union[FileSource, BigQuerySource],
+        self, feature_refs: List[str], entity_source: Union[FileSource, BigQuerySource]
     ):
         """
         Launch a historical feature retrieval job.
@@ -442,3 +457,18 @@ class Client:
             return get_remote_job_from_proto(
                 self._job_service, self._feast._extra_grpc_params, response.job
             )
+
+    def get_health_metrics(
+        self,
+        project: str,
+        table_names: List[str],
+    ) -> Dict[str, List[str]]:
+        if not self._use_job_service:
+            return get_health_metrics(self, project, table_names)
+        else:
+            request = GetHealthMetricsRequest(
+                project=cast(str, project),
+                table_names=table_names,
+            )
+            response = self._job_service.GetHealthMetrics(request)
+            return {"passed": response.passed, "failed": response.failed}

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -105,6 +105,12 @@ class ConfigOptions(metaclass=ConfigMeta):
     # SparkApplication resource template for Historical Retrieval Jobs
     SPARK_K8S_HISTORICAL_RETRIEVAL_TEMPLATE_PATH: Optional[str] = ""
 
+    #: Default Redis host
+    SPARK_METRICS_REDIS_HOST: Optional[str] = ""
+
+    #: Default Redis port
+    SPARK_METRICS_REDIS_PORT: Optional[str] = ""
+
     #: File format of historical retrieval features
     HISTORICAL_FEATURE_OUTPUT_FORMAT: str = "parquet"
 

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -105,10 +105,10 @@ class ConfigOptions(metaclass=ConfigMeta):
     # SparkApplication resource template for Historical Retrieval Jobs
     SPARK_K8S_HISTORICAL_RETRIEVAL_TEMPLATE_PATH: Optional[str] = ""
 
-    #: Default Redis host
+    #: Default Redis host to Redis Instance which stores Spark Ingestion Job metrics
     SPARK_METRICS_REDIS_HOST: Optional[str] = None
 
-    #: Default Redis port
+    #: Default Redis port to Redis Instance which stores Spark Ingestion Job metrics
     SPARK_METRICS_REDIS_PORT: Optional[str] = None
 
     #: File format of historical retrieval features

--- a/python/feast_spark/constants.py
+++ b/python/feast_spark/constants.py
@@ -106,10 +106,10 @@ class ConfigOptions(metaclass=ConfigMeta):
     SPARK_K8S_HISTORICAL_RETRIEVAL_TEMPLATE_PATH: Optional[str] = ""
 
     #: Default Redis host
-    SPARK_METRICS_REDIS_HOST: Optional[str] = ""
+    SPARK_METRICS_REDIS_HOST: Optional[str] = None
 
     #: Default Redis port
-    SPARK_METRICS_REDIS_PORT: Optional[str] = ""
+    SPARK_METRICS_REDIS_PORT: Optional[str] = None
 
     #: File format of historical retrieval features
     HISTORICAL_FEATURE_OUTPUT_FORMAT: str = "parquet"

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -20,6 +20,7 @@ from feast_spark import Client as Client
 from feast_spark.api import JobService_pb2_grpc
 from feast_spark.api.JobService_pb2 import (
     CancelJobResponse,
+    GetHealthMetricsResponse,
     GetHistoricalFeaturesRequest,
     GetHistoricalFeaturesResponse,
     GetJobResponse,
@@ -52,6 +53,7 @@ from feast_spark.pyspark.abc import (
     StreamIngestionJob,
 )
 from feast_spark.pyspark.launcher import (
+    get_health_metrics,
     get_job_by_id,
     get_stream_to_online_ingestion_params,
     list_jobs,
@@ -225,7 +227,9 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             request.table_name, request.project
         )
         unschedule_offline_to_online_ingestion(
-            client=self.client, project=request.project, feature_table=feature_table,
+            client=self.client,
+            project=request.project,
+            feature_table=feature_table,
         )
         return UnscheduleOfflineToOnlineIngestionJobResponse()
 
@@ -343,6 +347,15 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
         """Get details of a single job"""
         job = get_job_by_id(request.job_id, client=self.client)
         return GetJobResponse(job=_job_to_proto(job))
+
+    def GetHealthMetrics(self, request, context):
+        """Return ingestion jobs health metrics"""
+        metrics = get_health_metrics(
+            project=request.project, table_names=request.table_names, client=self.client
+        )
+        return GetHealthMetricsResponse(
+            passed=metrics["passed"], failed=metrics["failed"]
+        )
 
 
 def start_prometheus_serving(port: int = 8080) -> None:

--- a/python/feast_spark/job_service.py
+++ b/python/feast_spark/job_service.py
@@ -227,9 +227,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             request.table_name, request.project
         )
         unschedule_offline_to_online_ingestion(
-            client=self.client,
-            project=request.project,
-            feature_table=feature_table,
+            client=self.client, project=request.project, feature_table=feature_table,
         )
         return UnscheduleOfflineToOnlineIngestionJobResponse()
 

--- a/python/feast_spark/pyspark/launcher.py
+++ b/python/feast_spark/pyspark/launcher.py
@@ -294,8 +294,8 @@ def create_bq_view_of_joined_features_and_entities(
     source: BigQuerySource, entity_source: BigQuerySource, entity_names: List[str]
 ) -> BigQuerySource:
     """
-    Creates BQ view that joins tables from `source` and `entity_source` with join key derived from `entity_names`.
-Returns BigQuerySource with reference to created view. The BQ view will be created in the same BQ dataset as `entity_source`.
+        Creates BQ view that joins tables from `source` and `entity_source` with join key derived from `entity_names`.
+    Returns BigQuerySource with reference to created view. The BQ view will be created in the same BQ dataset as `entity_source`.
     """
     from google.cloud import bigquery
 
@@ -486,9 +486,7 @@ def get_job_by_id(job_id: str, client: "Client") -> SparkJob:
 
 
 def get_health_metrics(
-    client: "Client",
-    project: str,
-    table_names: List[str],
+    client: "Client", project: str, table_names: List[str],
 ) -> Dict[str, List[str]]:
     all_redis_keys = [f"{project}:{table}" for table in table_names]
     metrics = client.metrics_redis.mget(all_redis_keys)
@@ -497,7 +495,9 @@ def get_health_metrics(
     failed_feature_tables = []
 
     for i, name in enumerate(table_names):
-        feature_table = client.feature_store.get_feature_table(project=project, name=name)
+        feature_table = client.feature_store.get_feature_table(
+            project=project, name=name
+        )
         max_age = feature_table.max_age
         # Only perform ingestion health checks for Feature tables with max_age
         if not max_age:
@@ -505,8 +505,12 @@ def get_health_metrics(
             break
 
         # Ensure ingestion times are in epoch timings
-        last_ingestion_time = json.loads(metrics[i])["last_consumed_kafka_timestamp"]["value"]
-        valid_ingestion_time = datetime.timestamp(datetime.now() - timedelta(seconds=max_age))
+        last_ingestion_time = json.loads(metrics[i])["last_consumed_kafka_timestamp"][
+            "value"
+        ]
+        valid_ingestion_time = datetime.timestamp(
+            datetime.now() - timedelta(seconds=max_age)
+        )
 
         # Check if latest ingestion timestamp > cur_time - max_age
         if valid_ingestion_time > last_ingestion_time:

--- a/python/requirements-ci.txt
+++ b/python/requirements-ci.txt
@@ -23,3 +23,4 @@ pytest-mock==1.10.4
 PyYAML==5.3.1
 great-expectations==0.13.2
 adlfs==0.5.9
+redis==4.1.*

--- a/python/setup.py
+++ b/python/setup.py
@@ -52,6 +52,7 @@ REQUIRED = [
     "grpcio-tools==1.31.0",
     "mypy-protobuf==2.5",
     "croniter==1.*",
+    "redis==4.1.*",
 ]
 
 # README file from Feast repo root directory


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, when online retrieval returns null, it's not possible to determine if upstream ingestion jobs faced issues. This MR exposes the possibility to connect to a Redis instance which stores ingestion job status of Feature Tables based on the following format:
```
// Setting key
set default:my_feature_table '{"last_consumed_kafka_timestamp": {"value": 1645500635}}'
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New get_health_metrics method to retrieve ingestion job health of a list of Feature tables
```
