### PR TITLE
Add last processed event timestamp to streaming job

### DIFF
--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -120,6 +120,12 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-mapreduce</artifactId>
             <version>${hbase.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -234,6 +240,12 @@
             <artifactId>wiremock-jre8</artifactId>
             <version>2.27.2</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b12</version>
         </dependency>
     </dependencies>
 

--- a/spark/ingestion/src/main/scala/org/apache/spark/metrics/source/StreamingMetricSource.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/metrics/source/StreamingMetricSource.scala
@@ -19,6 +19,8 @@ package org.apache.spark.metrics.source
 import org.apache.spark.metrics.AtomicLongGauge
 import org.apache.spark.sql.streaming.StreamingQueryProgress
 
+import java.time.Instant
+
 class StreamingMetricSource extends BaseMetricSource {
   override val sourceName: String = StreamingMetricSource.sourceName
 
@@ -30,11 +32,19 @@ class StreamingMetricSource extends BaseMetricSource {
     metricRegistry.register(gaugeWithLabels("processed_rows_per_second"), new AtomicLongGauge())
   private val LAST_CONSUMED_KAFKA_TIMESTAMP_GAUGE =
     metricRegistry.register(gaugeWithLabels("last_consumed_kafka_timestamp"), new AtomicLongGauge())
+  private val LAST_PROCESSED_EVENT_TIMESTAMP_GAUGE =
+    metricRegistry.register(
+      gaugeWithLabels("last_processed_event_timestamp"),
+      new AtomicLongGauge()
+    )
 
   def updateStreamingProgress(progress: StreamingQueryProgress): Unit = {
     BATCH_DURATION_GAUGE.value.set(progress.batchDuration)
     INPUT_ROWS_PER_SECOND_GAUGE.value.set(progress.inputRowsPerSecond.toLong)
     PROCESSED_ROWS_PER_SECOND_GAUGE.value.set(progress.processedRowsPerSecond.toLong)
+
+    val epochTimestamp = Instant.parse(progress.timestamp).getEpochSecond
+    LAST_PROCESSED_EVENT_TIMESTAMP_GAUGE.value.set(epochTimestamp)
   }
 
   def updateKafkaTimestamp(timestamp: Long): Unit = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds a "heartbeat-like" metric to monitor the health of streaming ingestion jobs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
