### PR TITLE
Paritioned entity source

### DIFF
--- a/python/feast_spark/pyspark/launchers/k8s/k8s.py
+++ b/python/feast_spark/pyspark/launchers/k8s/k8s.py
@@ -74,6 +74,10 @@ def _truncate_label(label: str) -> str:
     return label[:63]
 
 
+class JobNotFoundException(Exception):
+    pass
+
+
 class KubernetesJobMixin:
     def __init__(self, api: CustomObjectsApi, namespace: str, job_id: str):
         self._api = api
@@ -85,17 +89,20 @@ class KubernetesJobMixin:
 
     def get_error_message(self) -> str:
         job = _get_job_by_id(self._api, self._namespace, self._job_id)
-        assert job is not None
+        if job is None:
+            raise JobNotFoundException()
         return job.job_error_message
 
     def get_status(self) -> SparkJobStatus:
         job = _get_job_by_id(self._api, self._namespace, self._job_id)
-        assert job is not None
+        if job is None:
+            raise JobNotFoundException
         return job.state
 
     def get_start_time(self) -> datetime:
         job = _get_job_by_id(self._api, self._namespace, self._job_id)
-        assert job is not None
+        if job is None:
+            raise JobNotFoundException
         return job.start_time
 
     def cancel(self):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The bigquery table corresponds to the entity source should be partitioned in order to achieve better performance for historical retrieval job.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
