### PR TITLE
Instantiate Jedis client lazily and only once per JVM process

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -67,6 +67,12 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
 
   lazy val isClusterMode: Boolean = checkIfInClusterMode(endpoint)
 
+  lazy val pipelineProvider: PipelineProvider = if (isClusterMode) {
+    ClusterPipelineProvider(endpoint)
+  } else {
+    SingleNodePipelineProvider(newJedisClient(endpoint))
+  }
+
   def newJedisClient(endpoint: RedisEndpoint): Jedis = {
     val jedis = new Jedis(endpoint.host, endpoint.port)
     if (endpoint.password.nonEmpty) {
@@ -94,12 +100,6 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
     dataToStore.foreachPartition { partition: Iterator[Row] =>
       java.security.Security.setProperty("networkaddress.cache.ttl", "3");
       java.security.Security.setProperty("networkaddress.cache.negative.ttl", "0");
-
-      val pipelineProvider = if (isClusterMode) {
-        ClusterPipelineProvider(endpoint)
-      } else {
-        SingleNodePipelineProvider(newJedisClient(endpoint))
-      }
 
       // grouped iterator to only allocate memory for a portion of rows
       partition.grouped(properties.pipelineSize).foreach { batch =>
@@ -146,7 +146,6 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
         }
         writePipeline.close()
       }
-      pipelineProvider.close()
     }
     dataToStore.unpersist()
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently the Jedis client is instantiated for each partition processed, and closed after use. In production, we noticed that there are some connection leak, which we suspect is due to connections that are not cleaned properly during retries. Instantiating Jedis client only once 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
