### PR TITLE
Initialize cluster provider / jedis pool only once

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/PipelineProvider.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/PipelineProvider.scala
@@ -16,6 +16,7 @@
  */
 package feast.ingestion.stores.redis
 
+import redis.clients.jedis.Response
 import redis.clients.jedis.commands.PipelineBinaryCommands
 
 import java.io.Closeable
@@ -25,12 +26,7 @@ import java.io.Closeable
   */
 trait PipelineProvider {
 
-  type UnifiedPipeline = PipelineBinaryCommands with Closeable
-
-  /**
-    * @return an interface for executing pipeline commands
-    */
-  def pipeline(): UnifiedPipeline
+  def withPipeline[T](ops: PipelineBinaryCommands => T): T
 
   /**
     * Close client connection

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/PipelineProviderFactory.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/PipelineProviderFactory.scala
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2022 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.stores.redis
+
+import redis.clients.jedis.Jedis
+
+import scala.collection.mutable
+import scala.util.Try
+
+object PipelineProviderFactory {
+
+  private lazy val providers: mutable.Map[RedisEndpoint, PipelineProvider] = mutable.Map.empty
+
+  private def newJedisClient(endpoint: RedisEndpoint): Jedis = {
+    val jedis = new Jedis(endpoint.host, endpoint.port)
+    if (endpoint.password.nonEmpty) {
+      jedis.auth(endpoint.password)
+    }
+    jedis
+  }
+
+  private def checkIfInClusterMode(endpoint: RedisEndpoint): Boolean = {
+    val jedis     = newJedisClient(endpoint)
+    val isCluster = Try(jedis.clusterInfo()).isSuccess
+    jedis.close()
+    isCluster
+  }
+
+  private def clusterPipelineProvider(endpoint: RedisEndpoint): PipelineProvider = {
+    ClusterPipelineProvider(endpoint)
+  }
+
+  private def singleNodePipelineProvider(endpoint: RedisEndpoint): PipelineProvider = {
+    SingleNodePipelineProvider(endpoint)
+  }
+
+  def newProvider(endpoint: RedisEndpoint): PipelineProvider = {
+    if (checkIfInClusterMode(endpoint)) {
+      clusterPipelineProvider(endpoint)
+    }
+    singleNodePipelineProvider(endpoint)
+  }
+
+  def provider(endpoint: RedisEndpoint): PipelineProvider = {
+    providers.getOrElseUpdate(endpoint, newProvider(endpoint))
+  }
+}


### PR DESCRIPTION
Signed-off-by: khorshuheng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, we are constantly creating and destroying connections, which isn't necessary.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
